### PR TITLE
[async.synop], [async.async.result] Remove class=void template parameter

### DIFF
--- a/src/async.tex
+++ b/src/async.tex
@@ -12,7 +12,7 @@ namespace experimental {
 namespace net {
 inline namespace v1 {
 
-  template<class CompletionToken, class Signature, class = void>
+  template<class CompletionToken, class Signature>
     class async_result;
 
   template<class CompletionToken, class Signature>
@@ -708,7 +708,7 @@ namespace experimental {
 namespace net {
 inline namespace v1 {
 
-  template<class CompletionToken, class Signature, class = void>
+  template<class CompletionToken, class Signature>
   class async_result
   {
   public:


### PR DESCRIPTION
This was a minor design change approved by LEWG in Kona.

https://github.com/chriskohlhoff/asio-tr2/wiki/IssuesForLEWGInKona
