### PR TITLE
Remove unneeded is_executor specializations

### DIFF
--- a/src/async.tex
+++ b/src/async.tex
@@ -2192,8 +2192,6 @@ inline namespace v1 {
     template<class Executor> const Executor* target() const noexcept;
   };
 
-  template<> struct is_executor<executor> : true_type {};
-
   // executor comparisons:
 
   bool operator==(const executor& a, const executor& b) noexcept;

--- a/src/basicioservices.tex
+++ b/src/basicioservices.tex
@@ -355,8 +355,6 @@ inline namespace v1 {
   bool operator!=(const io_context::executor_type& a,
                   const io_context::executor_type& b) noexcept;
 
-  template<> struct is_executor<io_context::executor_type> : true_type {};
-
 } // inline namespace v1
 } // namespace net
 } // namespace experimental


### PR DESCRIPTION
The primary template for is_executor is specified to yield true_type if the Executor template parameter meets the syntactic requirements of an Executor. This means that these specializations are not required.
