### PR TITLE
[buffer.reqmts] relax BidirectionalIterator requirements

### DIFF
--- a/src/buffers.tex
+++ b/src/buffers.tex
@@ -331,7 +331,7 @@ denotes a (possibly const) value of type \tcode{X}, and \tcode{u} denotes an ide
 
 \tcode{net::buffer_sequence_begin(x)}\br
 \tcode{net::buffer_sequence_end(x)}  &
-An iterator type meeting the requirements for bidirectional iterators (\CppXref{bidirectional.iterators}) whose value type is convertible to \tcode{mutable_buffer}.  &
+An iterator type whose value type is convertible to \tcode{mutable_buffer}, and which satisfies all the requirements for bidirectional iterators (\CppXref{bidirectional.iterators}) except that, for two user-defined dereferenceable iterators \tcode{a} and \tcode{b} where \tcode{a == b}, there is no requirement that \tcode{a} and \tcode{b} refer to the same object.  &
   \\ \rowsep
 
 \tcode{X u(x);}
@@ -391,7 +391,7 @@ In Table~\ref{tab:buffer.reqmts.constbuffersequence.requirements}, \tcode{x} den
 
 \tcode{net::buffer_sequence_begin(x)}\br
 \tcode{net::buffer_sequence_end(x)}  &
-An iterator type meeting the requirements for bidirectional iterators (\CppXref{bidirectional.iterators}) whose value type is convertible to \tcode{const_buffer}.  &
+An iterator type whose value type is convertible to \tcode{const_buffer}, and which satisfies all the requirements for bidirectional iterators (\CppXref{bidirectional.iterators}) except that, for two user-defined dereferenceable iterators \tcode{a} and \tcode{b} where \tcode{a == b}, there is no requirement that \tcode{a} and \tcode{b} refer to the same object.  &
   \\ \rowsep
 
 \tcode{X u(x);}


### PR DESCRIPTION
This change adopts proposed wording from N4606 ([path.itr]/2) to relax the **BidirectionalIterator** requirements for buffer sequence iterators, allowing lvalues to be returned.

The wording from N4606 reads:

> A path::iterator is a constant iterator satisfying all the requirements of a bidirectional iterator (24.2.6)
> except that, for dereferenceable iterators a and b of type path::iterator with a == b, there is no requirement that *a and *b are bound to the same object. Its value_type is path.
