### PR TITLE
Shorten some subclause stable names

### DIFF
--- a/src/async.tex
+++ b/src/async.tex
@@ -1971,7 +1971,7 @@ template<class Func, class ProtoAllocator>
 
 
 
-\rSec2[async.system.exec.comparisons]{\tcode{system_executor} comparisons}
+\rSec2[async.system.exec.cmp]{\tcode{system_executor} comparisons}
 
 \begin{itemdecl}
 bool operator==(const system_executor&, const system_executor&) noexcept;
@@ -2491,7 +2491,7 @@ template<class Executor> const Executor* target() const noexcept;
 
 
 
-\rSec2[async.executor.comparisons]{\tcode{executor} comparisons}
+\rSec2[async.executor.comp]{\tcode{executor} comparisons}
 
 \begin{itemdecl}
 bool operator==(const executor& a, const executor& b) noexcept;
@@ -3193,7 +3193,7 @@ template<class Func, class ProtoAllocator>
 
 
 
-\rSec2[async.strand.comparisons]{\tcode{strand} comparisons}
+\rSec2[async.strand.comp]{\tcode{strand} comparisons}
 
 \begin{itemdecl}
 bool operator==(const strand<Executor>& a, const strand<Executor>& b);

--- a/src/async.tex
+++ b/src/async.tex
@@ -3434,7 +3434,7 @@ Atomically stores \tcode{forward_as_tuple(forward<A$_0$>(a$_0$), ..., forward<A$
 \end{LongTable}
 
 
-\rSec1[async.packaged.task.spec]{Partial specialization of \tcode{async_result} for \tcode{packaged_task}}
+\rSec1[async.pkg.task.spec]{Partial specialization of \tcode{async_result} for \tcode{packaged_task}}
 
 \begin{itemdecl}
 namespace std {

--- a/src/basicioservices.tex
+++ b/src/basicioservices.tex
@@ -485,7 +485,7 @@ template<class Func, class ProtoAllocator>
 
 
 
-\rSec2[io_context.exec.comparisons]{\tcode{io_context::executor_type} comparisons}
+\rSec2[io_context.exec.comp]{\tcode{io_context::executor_type} comparisons}
 
 \begin{itemdecl}
 bool operator==(const io_context::executor_type& a,

--- a/src/buffers.tex
+++ b/src/buffers.tex
@@ -295,7 +295,7 @@ inline namespace v1 {
 \rSec1[buffer.reqmts]{Requirements}
 
 
-\rSec2[buffer.reqmts.mutablebuffersequence]{Mutable buffer sequence requirements}
+\rSec2[buffer.reqmts.mutable.buf.seq]{Mutable buffer sequence requirements}
 
 \pnum
 A \defn{mutable buffer sequence} represents a set of memory regions that may be used to receive the output of an operation, such as the \tcode{receive} operation of a socket.
@@ -488,7 +488,7 @@ Removes \tcode{n} bytes from beginning of the readable bytes. If \tcode{n} is gr
 \rSec2[buffer.reqmts.read.write]{Requirements on read and write operations}
 
 \pnum
-A \defn{read operation} is an operation that reads data into a mutable buffer sequence argument of a type meeting \tcode{MutableBufferSequence}~(\ref{buffer.reqmts.mutablebuffersequence}) requirements. The mutable buffer sequence specifies memory where the data should be placed. A read operation shall always fill a buffer in the sequence completely before proceeding to the next.
+A \defn{read operation} is an operation that reads data into a mutable buffer sequence argument of a type meeting \tcode{MutableBufferSequence}~(\ref{buffer.reqmts.mutable.buf.seq}) requirements. The mutable buffer sequence specifies memory where the data should be placed. A read operation shall always fill a buffer in the sequence completely before proceeding to the next.
 
 \pnum
 A \defn{write operation} is an operation that writes data from a constant buffer sequence argument of a type meeting \tcode{ConstBufferSequence}~(\ref{buffer.reqmts.constbuffersequence}) requirements. The constant buffer sequence specifies memory where the data to be written is located. A write operation shall always write a buffer in the sequence completely before proceeding to the next.
@@ -573,7 +573,7 @@ inline namespace v1 {
 \end{codeblock}
 
 \pnum
-The \tcode{mutable_buffer} class satisfies requirements of \tcode{MutableBufferSequence}~(\ref{buffer.reqmts.mutablebuffersequence}), \tcode{DefaultConstructible} (\CppXref{defaultconstructible}), and \tcode{CopyAssignable} (\CppXref{copyassignable}).
+The \tcode{mutable_buffer} class satisfies requirements of \tcode{MutableBufferSequence}~(\ref{buffer.reqmts.mutable.buf.seq}), \tcode{DefaultConstructible} (\CppXref{defaultconstructible}), and \tcode{CopyAssignable} (\CppXref{copyassignable}).
 
 \begin{itemdecl}
 mutable_buffer() noexcept;
@@ -755,7 +755,7 @@ This sub-clause contains templates that may be used to query the properties of a
 
 \tcode{template<class T>}\br
 \tcode{struct is_mutable_buffer_sequence}  &
-\tcode{T} meets the syntactic requirements for mutable buffer sequence~(\ref{buffer.reqmts.mutablebuffersequence}).  &
+\tcode{T} meets the syntactic requirements for mutable buffer sequence~(\ref{buffer.reqmts.mutable.buf.seq}).  &
 \tcode{T} is a complete type.  \\ \rowsep
 
 \tcode{template<class T>}\br

--- a/src/buffers.tex
+++ b/src/buffers.tex
@@ -356,7 +356,7 @@ equal(
 \end{LongTable}
 
 
-\rSec2[buffer.reqmts.constbuffersequence]{Constant buffer sequence requirements}
+\rSec2[buffer.reqmts.const.buf.seq]{Constant buffer sequence requirements}
 
 \pnum
 A \defn{constant buffer sequence} represents a set of memory regions that may be used as input to an operation, such as the \tcode{send} operation of a socket.
@@ -446,11 +446,11 @@ In Table~\ref{tab:buffer.reqmts.dynamicbuffer.requirements}, \tcode{x} denotes a
 \endhead
 
 \tcode{X::const_buffers_type}  &
-type meeting ConstBufferSequence~(\ref{buffer.reqmts.constbuffersequence}) requirements.  &
+type meeting ConstBufferSequence~(\ref{buffer.reqmts.const.buf.seq}) requirements.  &
  This type represents the memory associated with the readable bytes.  \\ \rowsep
 
 \tcode{X::mutable_buffers_type}  &
-type meeting MutableBufferSequence~(\ref{buffer.reqmts.constbuffersequence}) requirements.  &
+type meeting MutableBufferSequence~(\ref{buffer.reqmts.const.buf.seq}) requirements.  &
  This type represents the memory associated with the writable bytes.  \\ \rowsep
 
 \tcode{x1.size()}  &
@@ -491,7 +491,7 @@ Removes \tcode{n} bytes from beginning of the readable bytes. If \tcode{n} is gr
 A \defn{read operation} is an operation that reads data into a mutable buffer sequence argument of a type meeting \tcode{MutableBufferSequence}~(\ref{buffer.reqmts.mutable.buf.seq}) requirements. The mutable buffer sequence specifies memory where the data should be placed. A read operation shall always fill a buffer in the sequence completely before proceeding to the next.
 
 \pnum
-A \defn{write operation} is an operation that writes data from a constant buffer sequence argument of a type meeting \tcode{ConstBufferSequence}~(\ref{buffer.reqmts.constbuffersequence}) requirements. The constant buffer sequence specifies memory where the data to be written is located. A write operation shall always write a buffer in the sequence completely before proceeding to the next.
+A \defn{write operation} is an operation that writes data from a constant buffer sequence argument of a type meeting \tcode{ConstBufferSequence}~(\ref{buffer.reqmts.const.buf.seq}) requirements. The constant buffer sequence specifies memory where the data to be written is located. A write operation shall always write a buffer in the sequence completely before proceeding to the next.
 
 \pnum
 If a read or write operation is also an asynchronous operation~(\ref{async.reqmts.async}), the operation shall maintain one or more copies of the buffer sequence until such time as the operation no longer requires access to the memory specified by the buffers in the sequence. The program shall ensure the memory remains valid until:
@@ -657,7 +657,7 @@ inline namespace v1 {
 \end{codeblock}
 
 \pnum
-The \tcode{const_buffer} class satisfies requirements of \tcode{ConstBufferSequence}~(\ref{buffer.reqmts.constbuffersequence}), \tcode{DefaultConstructible} (\CppXref{defaultconstructible}), and \tcode{CopyAssignable} (\CppXref{copyassignable}).
+The \tcode{const_buffer} class satisfies requirements of \tcode{ConstBufferSequence}~(\ref{buffer.reqmts.const.buf.seq}), \tcode{DefaultConstructible} (\CppXref{defaultconstructible}), and \tcode{CopyAssignable} (\CppXref{copyassignable}).
 
 \begin{itemdecl}
 const_buffer() noexcept;
@@ -760,7 +760,7 @@ This sub-clause contains templates that may be used to query the properties of a
 
 \tcode{template<class T>}\br
 \tcode{struct is_const_buffer_sequence}  &
-\tcode{T} meets the syntactic requirements for constant buffer sequence~(\ref{buffer.reqmts.constbuffersequence}).  &
+\tcode{T} meets the syntactic requirements for constant buffer sequence~(\ref{buffer.reqmts.const.buf.seq}).  &
 \tcode{T} is a complete type.  \\ \rowsep
 
 \tcode{template<class T>}\br

--- a/src/bufferstreams.tex
+++ b/src/bufferstreams.tex
@@ -79,7 +79,7 @@ If \tcode{buffer_size(mb) > 0}, initiates an asynchronous operation to read one 
 A type \tcode{X} meets the \tcode{SyncWriteStream} requirements if it satisfies the requirements listed below.
 
 \pnum
-In the table below, \tcode{a} denotes a value of type \tcode{X}, \tcode{cb} denotes a (possibly const) value satisfying the \tcode{ConstBufferSequence}~(\ref{buffer.reqmts.constbuffersequence}) requirements, and \tcode{ec} denotes an object of type \tcode{error_code}.
+In the table below, \tcode{a} denotes a value of type \tcode{X}, \tcode{cb} denotes a (possibly const) value satisfying the \tcode{ConstBufferSequence}~(\ref{buffer.reqmts.const.buf.seq}) requirements, and \tcode{ec} denotes an object of type \tcode{error_code}.
 
 \begin{libreqtab3}
 {SyncWriteStream requirements}
@@ -112,7 +112,7 @@ If \tcode{buffer_size(cb) > 0}, writes one or more bytes of data to the stream \
 A type \tcode{X} meets the \tcode{AsyncWriteStream} requirements if it satisfies the requirements listed below.
 
 \pnum
-In the table below, \tcode{a} denotes a value of type \tcode{X}, \tcode{cb} denotes a (possibly const) value satisfying the \tcode{ConstBufferSequence}~(\ref{buffer.reqmts.constbuffersequence}) requirements, and \tcode{t} is a completion token.
+In the table below, \tcode{a} denotes a value of type \tcode{X}, \tcode{cb} denotes a (possibly const) value satisfying the \tcode{ConstBufferSequence}~(\ref{buffer.reqmts.const.buf.seq}) requirements, and \tcode{t} is a completion token.
 
 \begin{libreqtab3}
 {AsyncWriteStream requirements}
@@ -578,7 +578,7 @@ template<class SyncWriteStream, class DynamicBuffer, class CompletionCondition>
 \effects Writes data to the synchronous write stream~(\ref{buffer.stream.reqmts.syncwritestream}) object \tcode{stream} by performing zero or more calls to the stream's \tcode{write_some} member function.
 
 \pnum
-Data is written from the dynamic buffer~(\ref{buffer.reqmts.dynamicbuffer}) object \tcode{b}. A constant buffer sequence~(\ref{buffer.reqmts.constbuffersequence}) is obtained using \tcode{b.data()}. After the data has been written to the stream, the implementation performs \tcode{b.consume(n)}, where \tcode{n} is the number of bytes successfully written.
+Data is written from the dynamic buffer~(\ref{buffer.reqmts.dynamicbuffer}) object \tcode{b}. A constant buffer sequence~(\ref{buffer.reqmts.const.buf.seq}) is obtained using \tcode{b.data()}. After the data has been written to the stream, the implementation performs \tcode{b.consume(n)}, where \tcode{n} is the number of bytes successfully written.
 
 \pnum
 The \tcode{completion_condition} parameter specifies a completion condition to be called after each call to the stream's \tcode{write_some} member function. The completion condition is passed the \tcode{error_code} value from the most recent \tcode{write_some} call, and the total number of bytes transferred in the synchronous write operation so far. The completion condition return value specifies the maximum number of bytes to be written on the subsequent \tcode{write_some} call. Overloads where a completion condition is not specified behave as if called with an object of class \tcode{transfer_all}.
@@ -671,7 +671,7 @@ template<class AsyncWriteStream, class DynamicBuffer, class CompletionCondition,
 \effects Initiates an asynchronous operation to write data to the buffer-oriented asynchronous write stream~(\ref{buffer.stream.reqmts.asyncwritestream}) object \tcode{stream} by performing zero or more asynchronous write_some operations on the stream.
 
 \pnum
-Data is written from the dynamic buffer~(\ref{buffer.reqmts.dynamicbuffer}) object \tcode{b}. A constant buffer sequence~(\ref{buffer.reqmts.constbuffersequence}) is obtained using \tcode{b.data()}. After the data has been written to the stream, the implementation performs \tcode{b.consume(n)}, where \tcode{n} is the number of bytes successfully written.
+Data is written from the dynamic buffer~(\ref{buffer.reqmts.dynamicbuffer}) object \tcode{b}. A constant buffer sequence~(\ref{buffer.reqmts.const.buf.seq}) is obtained using \tcode{b.data()}. After the data has been written to the stream, the implementation performs \tcode{b.consume(n)}, where \tcode{n} is the number of bytes successfully written.
 
 \pnum
 The \tcode{completion_condition} parameter specifies a completion condition to be called prior to each asynchronous write_some operation. The completion condition is passed the \tcode{error_code} value from the most recent asynchronous write_some operation, and the total number of bytes transferred in the asynchronous write operation so far. The completion condition return value specifies the maximum number of bytes to be written on the subsequent asynchronous write_some operation. Overloads where a completion condition is not specified behave as if called with an object of class \tcode{transfer_all}.

--- a/src/bufferstreams.tex
+++ b/src/bufferstreams.tex
@@ -12,7 +12,7 @@
 A type \tcode{X} meets the \tcode{SyncReadStream} requirements if it satisfies the requirements listed in Table~\ref{tab:buffer.stream.reqmts.syncreadstream.requirements}.
 
 \pnum
-In Table~\ref{tab:buffer.stream.reqmts.syncreadstream.requirements}, \tcode{a} denotes a value of type \tcode{X}, \tcode{mb} denotes a (possibly const) value satisfying the \tcode{MutableBufferSequence}~(\ref{buffer.reqmts.mutablebuffersequence}) requirements, and \tcode{ec} denotes an object of type \tcode{error_code}.
+In Table~\ref{tab:buffer.stream.reqmts.syncreadstream.requirements}, \tcode{a} denotes a value of type \tcode{X}, \tcode{mb} denotes a (possibly const) value satisfying the \tcode{MutableBufferSequence}~(\ref{buffer.reqmts.mutable.buf.seq}) requirements, and \tcode{ec} denotes an object of type \tcode{error_code}.
 
 \begin{libreqtab3}
 {SyncReadStream requirements}
@@ -44,7 +44,7 @@ If \tcode{buffer_size(mb) > 0}, reads one or more bytes of data from the stream 
 A type \tcode{X} meets the \tcode{AsyncReadStream} requirements if it satisfies the requirements listed below.
 
 \pnum
-In the table below, \tcode{a} denotes a value of type \tcode{X}, \tcode{mb} denotes a (possibly const) value satisfying the \tcode{MutableBufferSequence}~(\ref{buffer.reqmts.mutablebuffersequence}) requirements, and \tcode{t} is a completion token.
+In the table below, \tcode{a} denotes a value of type \tcode{X}, \tcode{mb} denotes a (possibly const) value satisfying the \tcode{MutableBufferSequence}~(\ref{buffer.reqmts.mutable.buf.seq}) requirements, and \tcode{t} is a completion token.
 
 \begin{libreqtab3}
 {AsyncReadStream requirements}
@@ -386,7 +386,7 @@ template<class SyncReadStream, class DynamicBuffer,
 \effects Clears \tcode{ec}, then reads data from the synchronous read stream~(\ref{buffer.stream.reqmts.syncreadstream}) object \tcode{stream} by performing zero or more calls to the stream's \tcode{read_some} member function.
 
 \pnum
-Data is placed into the dynamic buffer~(\ref{buffer.reqmts.dynamicbuffer}) object \tcode{b}. A mutable buffer sequence~(\ref{buffer.reqmts.mutablebuffersequence}) is obtained prior to each \tcode{read_some} call using \tcode{b.prepare(N)}, where \tcode{N} is an unspecified value less than or equal to \tcode{b.max_size() - b.size()}. \enternote Implementations are encouraged to use \tcode{b.capacity()} when determining \tcode{N}, to minimize the number of \tcode{read_some} calls performed on the stream. \exitnote After each \tcode{read_some} call, the implementation performs \tcode{b.commit(n)}, where \tcode{n} is the return value from \tcode{read_some}.
+Data is placed into the dynamic buffer~(\ref{buffer.reqmts.dynamicbuffer}) object \tcode{b}. A mutable buffer sequence~(\ref{buffer.reqmts.mutable.buf.seq}) is obtained prior to each \tcode{read_some} call using \tcode{b.prepare(N)}, where \tcode{N} is an unspecified value less than or equal to \tcode{b.max_size() - b.size()}. \enternote Implementations are encouraged to use \tcode{b.capacity()} when determining \tcode{N}, to minimize the number of \tcode{read_some} calls performed on the stream. \exitnote After each \tcode{read_some} call, the implementation performs \tcode{b.commit(n)}, where \tcode{n} is the return value from \tcode{read_some}.
 
 \pnum
 The \tcode{completion_condition} parameter specifies a completion condition to be called prior to each call to the stream's \tcode{read_some} member function. The completion condition is passed the \tcode{error_code} value from the most recent \tcode{read_some} call, and the total number of bytes transferred in the synchronous read operation so far. The completion condition return value specifies the maximum number of bytes to be read on the subsequent \tcode{read_some} call. Overloads where a completion condition is not specified behave as if called with an object of class \tcode{transfer_all}.
@@ -479,7 +479,7 @@ template<class AsyncReadStream, class DynamicBuffer, class CompletionCondition,
 \effects Initiates an asynchronous operation to read data from the buffer-oriented asynchronous read stream~(\ref{buffer.stream.reqmts.asyncreadstream}) object \tcode{stream} by performing one or more asynchronous read_some operations on the stream.
 
 \pnum
-Data is placed into the dynamic buffer~(\ref{buffer.reqmts.dynamicbuffer}) object \tcode{b}. A mutable buffer sequence~(\ref{buffer.reqmts.mutablebuffersequence}) is obtained prior to each \tcode{async_read_some} call using \tcode{b.prepare(N)}, where \tcode{N} is an unspecified value such that \tcode{N} is less than or equal to \tcode{b.max_size() - b.size()}. \enternote Implementations are encouraged to use \tcode{b.capacity()} when determining \tcode{N}, to minimize the number of asynchronous read_some operations performed on the stream. \exitnote After the completion of each asynchronous read_some operation, the implementation performs \tcode{b.commit(n)}, where \tcode{n} is the value passed to the asynchronous read_some operation's completion handler.
+Data is placed into the dynamic buffer~(\ref{buffer.reqmts.dynamicbuffer}) object \tcode{b}. A mutable buffer sequence~(\ref{buffer.reqmts.mutable.buf.seq}) is obtained prior to each \tcode{async_read_some} call using \tcode{b.prepare(N)}, where \tcode{N} is an unspecified value such that \tcode{N} is less than or equal to \tcode{b.max_size() - b.size()}. \enternote Implementations are encouraged to use \tcode{b.capacity()} when determining \tcode{N}, to minimize the number of asynchronous read_some operations performed on the stream. \exitnote After the completion of each asynchronous read_some operation, the implementation performs \tcode{b.commit(n)}, where \tcode{n} is the value passed to the asynchronous read_some operation's completion handler.
 
 \pnum
 The \tcode{completion_condition} parameter specifies a completion condition to be called prior to each asynchronous read_some operation. The completion condition is passed the \tcode{error_code} value from the most recent asynchronous read_some operation, and the total number of bytes transferred in the asynchronous read operation so far. The completion condition return value specifies the maximum number of bytes to be read on the subsequent asynchronous read_some operation. Overloads where a completion condition is not specified behave as if called with an object of class \tcode{transfer_all}.
@@ -716,7 +716,7 @@ template<class SyncReadStream, class DynamicBuffer>
 \effects Reads data from the buffer-oriented synchronous read stream~(\ref{buffer.stream.reqmts.syncreadstream}) object \tcode{stream} by performing zero or more calls to the stream's \tcode{read_some} member function, until the input sequence of the dynamic buffer~(\ref{buffer.reqmts.dynamicbuffer}) object \tcode{b} contains the specified delimiter \tcode{delim}.
 
 \pnum
-Data is placed into the dynamic buffer object \tcode{b}. A mutable buffer sequence~(\ref{buffer.reqmts.mutablebuffersequence}) is obtained prior to each \tcode{read_some} call using \tcode{b.prepare(N)}, where \tcode{N} is an unspecified value such that \tcode{N <= max_size() - size()}. \enternote Implementations are encouraged to use \tcode{b.capacity()} when determining \tcode{N}, to minimize the number of \tcode{read_some} calls performed on the stream. \exitnote After each \tcode{read_some} call, the implementation performs \tcode{b.commit(n)}, where \tcode{n} is the return value from \tcode{read_some}.
+Data is placed into the dynamic buffer object \tcode{b}. A mutable buffer sequence~(\ref{buffer.reqmts.mutable.buf.seq}) is obtained prior to each \tcode{read_some} call using \tcode{b.prepare(N)}, where \tcode{N} is an unspecified value such that \tcode{N <= max_size() - size()}. \enternote Implementations are encouraged to use \tcode{b.capacity()} when determining \tcode{N}, to minimize the number of \tcode{read_some} calls performed on the stream. \exitnote After each \tcode{read_some} call, the implementation performs \tcode{b.commit(n)}, where \tcode{n} is the return value from \tcode{read_some}.
 
 \pnum
 The synchronous read_until operation continues until:
@@ -760,7 +760,7 @@ template<class AsyncReadStream, class DynamicBuffer, class CompletionToken>
 \effects Initiates an asynchronous operation to read data from the buffer-oriented asynchronous read stream~(\ref{buffer.stream.reqmts.asyncreadstream}) object \tcode{stream} by performing zero or more asynchronous read_some operations on the stream, until the readable bytes of the dynamic buffer~(\ref{buffer.reqmts.dynamicbuffer}) object \tcode{b} contain the specified delimiter \tcode{delim}.
 
 \pnum
-Data is placed into the dynamic buffer object \tcode{b}. A mutable buffer sequence~(\ref{buffer.reqmts.mutablebuffersequence}) is obtained prior to each \tcode{async_read_some} call using \tcode{b.prepare(N)}, where \tcode{N} is an unspecified value such that \tcode{N <= max_size() - size()}. \enternote Implementations are encouraged to use \tcode{b.capacity()} when determining \tcode{N}, to minimize the number of asynchronous read_some operations performed on the stream. \exitnote After the completion of each asynchronous read_some operation, the implementation performs \tcode{b.commit(n)}, where \tcode{n} is the value passed to the asynchronous read_some operation's completion handler.
+Data is placed into the dynamic buffer object \tcode{b}. A mutable buffer sequence~(\ref{buffer.reqmts.mutable.buf.seq}) is obtained prior to each \tcode{async_read_some} call using \tcode{b.prepare(N)}, where \tcode{N} is an unspecified value such that \tcode{N <= max_size() - size()}. \enternote Implementations are encouraged to use \tcode{b.capacity()} when determining \tcode{N}, to minimize the number of asynchronous read_some operations performed on the stream. \exitnote After the completion of each asynchronous read_some operation, the implementation performs \tcode{b.commit(n)}, where \tcode{n} is the value passed to the asynchronous read_some operation's completion handler.
 
 \pnum
 The asynchronous read_until operation continues until:

--- a/src/internetprotocol.tex
+++ b/src/internetprotocol.tex
@@ -1824,7 +1824,7 @@ template<> struct hash<experimental::net::v1::ip::address_v6>;
 
 
 \indexlibrary{\idxcode{basic_address_iterator}}%
-\rSec1[internet.address.iter]{Class template \tcode{ip::basic_address_iterator} specializations}
+\rSec1[internet.addr.iter]{Class template \tcode{ip::basic_address_iterator} specializations}
 
 \pnum
 The class template \tcode{basic_address_iterator} enables iteration over IP addresses in network byte order. This clause defines two specializations of the class template \tcode{basic_address_iterator}: \tcode{basic_address_iterator<address_v4>} and \tcode{basic_address_iterator<address_v6>}. The members and operational semantics of these specializations are defined below.

--- a/src/internetprotocol.tex
+++ b/src/internetprotocol.tex
@@ -757,7 +757,7 @@ template<class Allocator = allocator<char>>
 
 
 \indexlibrarytwo{address}{operator==}%
-\rSec2[internet.address.comparisons]{\tcode{ip::address} comparisons}
+\rSec2[internet.address.comp]{\tcode{ip::address} comparisons}
 
 \begin{itemdecl}
 constexpr bool operator==(const address& a, const address& b) noexcept;
@@ -1136,7 +1136,7 @@ static constexpr address_v4 broadcast() noexcept;
 
 
 
-\rSec2[internet.address.v4.comparisons]{\tcode{ip::address_v4} comparisons}
+\rSec2[internet.address.v4.comp]{\tcode{ip::address_v4} comparisons}
 
 \indexlibrarytwo{address_v4}{operator==}%
 \begin{itemdecl}
@@ -1631,7 +1631,7 @@ static constexpr address_v6 loopback() noexcept;
 
 
 
-\rSec2[internet.address.v6.comparisons]{\tcode{ip::address_v6} comparisons}
+\rSec2[internet.address.v6.comp]{\tcode{ip::address_v6} comparisons}
 
 \indexlibrarytwo{address_v6}{operator==}%
 \begin{itemdecl}
@@ -2266,7 +2266,7 @@ template<class Allocator = allocator<char>>
 
 
 
-\rSec2[internet.network.v4.comparisons]{\tcode{ip::network_v4} comparisons}
+\rSec2[internet.network.v4.comp]{\tcode{ip::network_v4} comparisons}
 
 \begin{itemdecl}
 constexpr bool operator==(const network_v4& a, const network_v4& b) noexcept;
@@ -2512,7 +2512,7 @@ template<class Allocator = allocator<char>>
 
 
 
-\rSec2[internet.network.v6.comparisons]{\tcode{ip::network_v6} comparisons}
+\rSec2[internet.network.v6.comp]{\tcode{ip::network_v6} comparisons}
 
 \begin{itemdecl}
 constexpr bool operator==(const network_v6& a, const network_v6& b) noexcept;
@@ -2783,7 +2783,7 @@ void port(port_type port_num) noexcept;
 
 
 
-\rSec2[internet.endpoint.comparisons]{\tcode{ip::basic_endpoint} comparisons}
+\rSec2[internet.endpoint.comp]{\tcode{ip::basic_endpoint} comparisons}
 
 \begin{itemdecl}
 template<class InternetProtocol>
@@ -3070,7 +3070,7 @@ template<class Allocator = allocator<char>>
 
 
 
-\rSec2[internet.resolver.entry.comparisons]{\tcode{op::basic_resolver_entry} comparisons}
+\rSec2[internet.resolver.entry.comp]{\tcode{op::basic_resolver_entry} comparisons}
 
 \begin{itemdecl}
 template<class InternetProtocol>
@@ -3297,7 +3297,7 @@ void swap(basic_resolver_results& that) noexcept;
 
 
 
-\rSec2[internet.resolver.results.comparisons]{\tcode{ip::basic_resolver_results} comparisons}
+\rSec2[internet.resolver.results.comp]{\tcode{ip::basic_resolver_results} comparisons}
 
 \begin{itemdecl}
 template<class InternetProtocol>
@@ -3948,7 +3948,7 @@ namespace ip {
 \enternote The constants \tcode{AF_INET}, \tcode{AF_INET6} and \tcode{SOCK_STREAM} are defined in the POSIX header file \tcode{<sys/socket.h>}. The constant \tcode{IPPROTO_TCP} is defined in the POSIX header file \tcode{<netinet/in.h>}. \exitnote
 
 
-\rSec2[internet.tcp.comparisons]{\tcode{ip::tcp} comparisons}
+\rSec2[internet.tcp.comp]{\tcode{ip::tcp} comparisons}
 
 \begin{itemdecl}
 constexpr bool operator==(const tcp& a, const tcp& b) noexcept;
@@ -4076,7 +4076,7 @@ namespace ip {
 \enternote The constants \tcode{AF_INET}, \tcode{AF_INET6} and \tcode{SOCK_DGRAM} are defined in the POSIX header file \tcode{<sys/socket.h>}. The constant \tcode{IPPROTO_UDP} is defined in the POSIX header file \tcode{<netinet/in.h>}. \exitnote
 
 
-\rSec2[internet.udp.comparisons]{\tcode{ip::udp} comparisons}
+\rSec2[internet.udp.comp]{\tcode{ip::udp} comparisons}
 
 \begin{itemdecl}
 constexpr bool operator==(const udp& a, const udp& b) noexcept;

--- a/src/internetprotocol.tex
+++ b/src/internetprotocol.tex
@@ -1951,7 +1951,7 @@ basic_address_iterator operator--(int) noexcept;
 
 
 \indexlibrary{\idxcode{basic_address_range}}%
-\rSec1[internet.address.range]{Class template \tcode{ip::basic_address_range} specializations}
+\rSec1[internet.addr.range]{Class template \tcode{ip::basic_address_range} specializations}
 
 \pnum
 The class template \tcode{basic_address_range} represents a range of IP addresses in network byte order. This clause defines two specializations of the class template \tcode{basic_address_range}: \tcode{basic_address_range<address_v4>} and \tcode{basic_address_range<address_v6>}. The members and operational semantics of these specializations are defined below.

--- a/src/summary.tex
+++ b/src/summary.tex
@@ -112,7 +112,7 @@ Internet protocol~(\ref{internet.reqmts.protocol})  \\ \rowsep
 I/O control command~(\ref{socket.reqmts.iocontrolcommand})  \\ \rowsep
 
 \tcode{MutableBufferSequence}  &
-mutable buffer sequence~(\ref{buffer.reqmts.mutablebuffersequence})  \\ \rowsep
+mutable buffer sequence~(\ref{buffer.reqmts.mutable.buf.seq})  \\ \rowsep
 
 \tcode{ProtoAllocator}  &
 proto-allocator~(\ref{async.reqmts.proto.allocator})  \\ \rowsep

--- a/src/summary.tex
+++ b/src/summary.tex
@@ -88,7 +88,7 @@ completion token~(\ref{async.reqmts.async.token})  \\ \rowsep
 connect condition~(\ref{socket.reqmts.connectcondition})  \\ \rowsep
 
 \tcode{ConstBufferSequence}  &
-constant buffer sequence~(\ref{buffer.reqmts.constbuffersequence})  \\ \rowsep
+constant buffer sequence~(\ref{buffer.reqmts.const.buf.seq})  \\ \rowsep
 
 \tcode{DynamicBuffer}  &
 dynamic buffer~(\ref{buffer.reqmts.dynamicbuffer})  \\ \rowsep


### PR DESCRIPTION
Some clause names are very long, and cause clause headings to wrap onto two lines. This reduces some of the worst, although there are still:

[buffer.stream.reqmts.syncwritestream]
[buffer.stream.reqmts.asyncwritestream]
[buffer.stream.reqmts.completioncondition]

And these which don't cause any wrapping problems:
 [socket.reqmts.endpointsequence]
 [socket.reqmts.acceptableprotocol]
 [socket.reqmts.gettablesocketoption]
 [socket.reqmts.settablesocketoption]
 [socket.reqmts.iocontrolcommand]
 [socket.reqmts.connectcondition]

Other abbreviations we could consider are socket -> sock, option -> opt, internet -> inet
