### PR TITLE
[internet.network.v6] const string_view&" -> string_view

### DIFF
--- a/src/internetprotocol.tex
+++ b/src/internetprotocol.tex
@@ -2392,8 +2392,8 @@ namespace ip {
   network_v6 make_network_v6(const char* str, error_code& ec) noexcept;
   network_v6 make_network_v6(const string& str);
   network_v6 make_network_v6(const string& str, error_code& ec) noexcept;
-  network_v6 make_network_v6(const string_view& str);
-  network_v6 make_network_v6(const string_view& str, error_code& ec) noexcept;
+  network_v6 make_network_v6(string_view str);
+  network_v6 make_network_v6(string_view str, error_code& ec) noexcept;
 
   // network_v6 I/O:
   template<class CharT, class Traits>
@@ -2552,8 +2552,8 @@ network_v6 make_network_v6(const char* str);
 network_v6 make_network_v6(const char* str, error_code& ec) noexcept;
 network_v6 make_network_v6(const string& str);
 network_v6 make_network_v6(const string& str, error_code& ec) noexcept;
-network_v6 make_network_v6(const string_view& str);
-network_v6 make_network_v6(const string_view& str, error_code& ec) noexcept;
+network_v6 make_network_v6(string_view str);
+network_v6 make_network_v6(string_view str, error_code& ec) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}


### PR DESCRIPTION
This what is done in the rest of the TS, and also
how string_view is passed to std::basic_string in
the IS.