### PR TITLE
Use 'using' (and 'alias') instead of 'typedef'

### DIFF
--- a/src/async.tex
+++ b/src/async.tex
@@ -346,7 +346,7 @@ A service shall provide an explicit constructor with a single parameter of lvalu
 class my_service : public execution_context::service
 {
 public:
-  typedef my_service key_type;
+  using key_type = my_service;
   explicit my_service(execution_context& ctx);
   my_service(execution_context& ctx, int some_value);
 private:
@@ -768,8 +768,8 @@ inline namespace v1 {
   class async_result
   {
   public:
-    typedef CompletionToken completion_handler_type;
-    typedef void return_type;
+    using completion_handler_type = CompletionToken;
+    using return_type = void;
 
     explicit async_result(completion_handler_type&) {}
     async_result(const async_result&) = delete;
@@ -841,9 +841,8 @@ inline namespace v1 {
   template<class CompletionToken, class Signature>
   struct async_completion
   {
-    typedef async_result<decay_t<CompletionToken>,
-      Signature>::completion_handler_type
-        completion_handler_type;
+    using completion_handler_type = async_result<decay_t<CompletionToken>,
+      Signature>::completion_handler_type;
 
     explicit async_completion(CompletionToken& t);
     async_completion(const async_completion&) = delete;
@@ -897,7 +896,7 @@ inline namespace v1 {
   template<class T, class ProtoAllocator = allocator<void>>
   struct associated_allocator
   {
-    typedef @\seebelow@ type;
+    using type = @\seebelow@;
 
     static type get(const T& t, const ProtoAllocator& a = ProtoAllocator()) noexcept;
   };
@@ -945,7 +944,7 @@ Shall not exit via an exception. Equivalent to \tcode{X::get(t, ProtoAllocator()
 \rSec2[async.assoc.alloc.members]{\tcode{associated_allocator} members}
 
 \begin{itemdecl}
-typedef @\seebelow@ type;
+using type = @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1349,7 +1348,7 @@ inline namespace v1 {
   template<class T, class Executor = system_executor>
   struct associated_executor
   {
-    typedef @\seebelow@ type;
+    using type = @\seebelow@;
 
     static type get(const T& t, const Executor& e = Executor()) noexcept;
   };
@@ -1397,7 +1396,7 @@ Shall not exit via an exception. Equivalent to \tcode{X::get(t, Executor())}.  \
 \rSec2[async.assoc.exec.members]{\tcode{associated_executor} members}
 
 \begin{itemdecl}
-typedef @\seebelow@ type;
+using type = @\seebelow@;
 \end{itemdecl}
 
 \begin{itemdescr}
@@ -1478,8 +1477,8 @@ inline namespace v1 {
   public:
     // types:
 
-    typedef T target_type;
-    typedef Executor executor_type;
+    using target_type = T;
+    using executor_type = Executor;
 
     // construct / copy / destroy:
 
@@ -1657,10 +1656,10 @@ inline namespace v1 {
   class async_result<executor_binder<T, Executor>, Signature>
   {
   public:
-    typedef executor_binder<
+    using completion_handler_type = executor_binder<
       typename async_result<T, Signature>::completion_handler_type,
-        Executor> completion_handler_type;
-    typedef typename async_result<T, Signature>::return_type return_type;
+        Executor>;
+    using return_type = typename async_result<T, Signature>::return_type;
 
     explicit async_result(completion_handler_type& h);
     async_result(const async_result&) = delete;
@@ -1711,7 +1710,7 @@ inline namespace v1 {
   template<class T, class Executor, class ProtoAllocator>
     struct associated_allocator<executor_binder<T, Executor>, ProtoAllocator>
   {
-    typedef associated_allocator_t<T, ProtoAllocator> type;
+    using type = associated_allocator_t<T, ProtoAllocator>;
 
     static type get(const executor_binder<T, Executor>& b,
                     const ProtoAllocator& a = ProtoAllocator()) noexcept;
@@ -1748,7 +1747,7 @@ inline namespace v1 {
   template<class T, class Executor, class Executor1>
     struct associated_executor<executor_binder<T, Executor>, Executor1>
   {
-    typedef Executor type;
+    using type = Executor;
 
     static type get(const executor_binder<T, Executor>& b,
                     const Executor1& e = Executor1()) noexcept;
@@ -1822,7 +1821,7 @@ inline namespace v1 {
   public:
     // types:
 
-    typedef Executor executor_type;
+    using executor_type = Executor;
 
     // construct / copy / destroy:
 
@@ -2131,7 +2130,7 @@ inline namespace v1 {
   public:
     // types:
 
-    typedef system_executor executor_type;
+    using executor_type = system_executor;
 
     // construct / copy / destroy:
 
@@ -2990,7 +2989,7 @@ inline namespace v1 {
   public:
     // types:
 
-    typedef Executor inner_executor_type;
+    using inner_executor_type = Executor;
 
     // construct / copy / destroy:
 
@@ -3407,7 +3406,7 @@ inline namespace v1 {
   {
   public:
     // use_future_t types:
-    typedef ProtoAllocator allocator_type;
+    using allocator_type = ProtoAllocator;
 
     // use_future_t members:
     constexpr use_future_t() noexcept(noexcept(allocator_type()));
@@ -3515,8 +3514,8 @@ For any executor type \tcode{E}, the associated object for the associator \tcode
 template<class ProtoAllocator, class Result, class... Args>
 class async_result<use_future_t<ProtoAllocator>, Result(Args...)>
 {
-  typedef @\seebelow@ completion_handler_type;
-  typedef @\seebelow@ return_type;
+  using completion_handler_type = @\seebelow@;
+  using return_type =  @\seebelow@;
 
   explicit async_result(completion_handler_type& h);
   async_result(const async_result&) = delete;
@@ -3629,8 +3628,8 @@ inline namespace v1 {
   class async_result<packaged_task<Result(Args...)>, Signature>
   {
   public:
-    typedef packaged_task<Result(Args...)> completion_handler_type;
-    typedef future<Result> return_type;
+    using completion_handler_type = packaged_task<Result(Args...)>;
+    using return_type = future<Result>;
 
     explicit async_result(completion_handler_type& h);
     async_result(const async_result&) = delete;

--- a/src/async.tex
+++ b/src/async.tex
@@ -3492,9 +3492,9 @@ The object \tcode{h} of type \tcode{H} is an asynchronous provider with an assoc
 The implementation provides a partial specialization \tcode{template <class Result, class... Args> async_result<T, Result(Args...)>} such that:
 \begin{itemize}
 \item
- the nested typedef \tcode{completion_handler_type} is a type \tcode{H};
+ the nested alias \tcode{completion_handler_type} is a type \tcode{H};
 \item
- the nested typedef \tcode{return_type} is \tcode{future<result_of_t<FD(decay_t<Args>...)>>}; and
+ the nested alias \tcode{return_type} is \tcode{future<result_of_t<FD(decay_t<Args>...)>>}; and
 \item
  when an object \tcode{r1} of type \tcode{async_result<T, Result(Args...)>} is constructed from \tcode{h}, the expression \tcode{r1.get()} returns a future with the same shared state as \tcode{h}.
 \end{itemize}

--- a/src/async.tex
+++ b/src/async.tex
@@ -3492,9 +3492,9 @@ The object \tcode{h} of type \tcode{H} is an asynchronous provider with an assoc
 The implementation provides a partial specialization \tcode{template <class Result, class... Args> async_result<T, Result(Args...)>} such that:
 \begin{itemize}
 \item
- the nested alias \tcode{completion_handler_type} is a type \tcode{H};
+ the nested type \tcode{completion_handler_type} is a type \tcode{H};
 \item
- the nested alias \tcode{return_type} is \tcode{future<result_of_t<FD(decay_t<Args>...)>>}; and
+ the nested type \tcode{return_type} is \tcode{future<result_of_t<FD(decay_t<Args>...)>>}; and
 \item
  when an object \tcode{r1} of type \tcode{async_result<T, Result(Args...)>} is constructed from \tcode{h}, the expression \tcode{r1.get()} returns a future with the same shared state as \tcode{h}.
 \end{itemize}

--- a/src/basicioservices.tex
+++ b/src/basicioservices.tex
@@ -37,7 +37,7 @@ inline namespace v1 {
     // types:
 
     class executor_type;
-    typedef @\textit{implementation-defined}@ count_type;
+    using count_type = @\textit{implementation-defined}@;
 
     // construct / copy / destroy:
 

--- a/src/buffers.tex
+++ b/src/buffers.tex
@@ -1106,8 +1106,8 @@ inline namespace v1 {
   {
   public:
     // types:
-    typedef const_buffer const_buffers_type;
-    typedef mutable_buffer mutable_buffers_type;
+    using const_buffers_type = const_buffer;
+    using mutable_buffers_type = mutable_buffer;
 
     // constructors:
     explicit dynamic_vector_buffer(vector<T, Allocator>& vec) noexcept;
@@ -1272,8 +1272,8 @@ inline namespace v1 {
   {
   public:
     // types:
-    typedef const_buffer const_buffers_type;
-    typedef mutable_buffer mutable_buffers_type;
+    using const_buffers_type = const_buffer;
+    using mutable_buffers_type = mutable_buffer;
 
     // constructors:
     explicit dynamic_string_buffer(basic_string<CharT, Traits, Allocator>& str) noexcept;

--- a/src/forward.tex
+++ b/src/forward.tex
@@ -27,9 +27,9 @@ inline namespace v1 {
   template<class Clock> struct wait_traits;
   template<class Clock, class WaitTraits = wait_traits<Clock>>
     class basic_waitable_timer;
-  typedef basic_waitable_timer<chrono::system_clock> system_timer;
-  typedef basic_waitable_timer<chrono::steady_clock> steady_timer;
-  typedef basic_waitable_timer<chrono::high_resolution_clock> high_resolution_timer;
+  using system_timer = basic_waitable_timer<chrono::system_clock>;
+  using steady_timer = basic_waitable_timer<chrono::steady_clock>;
+  using high_resolution_timer = basic_waitable_timer<chrono::high_resolution_clock>;
 
   template<class Protocol>
     class basic_socket;
@@ -53,12 +53,12 @@ inline namespace v1 {
     class address_v6;
     template<class Address>
       class basic_address_iterator;
-    typedef basic_address_iterator<address_v4> address_v4_iterator;
-    typedef basic_address_iterator<address_v6> address_v6_iterator;
+    using address_v4_iterator = basic_address_iterator<address_v4>;
+    using address_v6_iterator = basic_address_iterator<address_v6>;
     template<class Address>
       class basic_address_range;
-    typedef basic_address_range<address_v4> address_v4_range;
-    typedef basic_address_range<address_v6> address_v6_range;
+    using address_v4_range = basic_address_range<address_v4>;
+    using address_v6_range = basic_address_range<address_v6>;
     class network_v4;
     class network_v6;
     template<class InternetProtocol>

--- a/src/internetprotocol.tex
+++ b/src/internetprotocol.tex
@@ -29,8 +29,8 @@ namespace ip {
   error_code make_error_code(resolver_errc e) noexcept;
   error_condition make_error_condition(resolver_errc e) noexcept;
 
-  typedef uint_least16_t port_type;
-  typedef uint_least32_t scope_id_type;
+  using port_type = uint_least16_t;
+  using scope_id_type = uint_least32_t;
 
   struct v4_mapped_t {};
   constexpr v4_mapped_t v4_mapped;
@@ -112,15 +112,15 @@ namespace ip {
 
   template<class> class basic_address_iterator; // \notdef
   template<> class basic_address_iterator<address_v4>;
-  typedef basic_address_iterator<address_v4> address_v4_iterator;
+  using address_v4_iterator = basic_address_iterator<address_v4>;
   template<> class basic_address_iterator<address_v6>;
-  typedef basic_address_iterator<address_v6> address_v6_iterator;
+  using address_v6_iterator = basic_address_iterator<address_v6>;
 
   template<class> class basic_address_range; // \notdef
   template<> class basic_address_range<address_v4>;
-  typedef basic_address_range<address_v4> address_v4_range;
+  using address_v4_range = basic_address_range<address_v4>;
   template<> class basic_address_range<address_v6>;
-  typedef basic_address_range<address_v6> address_v6_range;
+  using address_v6_range = basic_address_range<address_v6>;
 
   class network_v4;
   class network_v6;
@@ -909,7 +909,7 @@ namespace ip {
   {
   public:
     // types:
-    typedef uint_least32_t uint_type;
+    using uint_type = uint_least32_t;
     struct bytes_type;
 
     // constructors:
@@ -1842,11 +1842,11 @@ namespace ip {
   {
   public:
     // types:
-    typedef @\placeholder{Address}@ value_type;
-    typedef ptrdiff_t difference_type;
-    typedef const @\placeholder{Address}@* pointer;
-    typedef const @\placeholder{Address}@& reference;
-    typedef input_iterator_tag iterator_category;
+    using value_type = @\placeholder{Address}@;
+    using difference_type = ptrdiff_t;
+    using pointer = const @\placeholder{Address}@*;
+    using reference = const @\placeholder{Address}@&;
+    using iterator_category = input_iterator_tag;
 
     // constructors:
     basic_address_iterator(const @\placeholder{Address}@& a) noexcept;
@@ -1969,7 +1969,7 @@ namespace ip {
   {
   public:
     // types:
-    typedef basic_address_iterator<@\placeholder{Address}@> iterator;
+    using iterator = basic_address_iterator<@\placeholder{Address}@>;
 
     // constructors:
     basic_address_range() noexcept;
@@ -2604,7 +2604,7 @@ namespace ip {
   {
   public:
     // types:
-    typedef InternetProtocol protocol_type;
+    using protocol_type = InternetProtocol;
 
     // constructors:
     constexpr basic_endpoint() noexcept;
@@ -2954,8 +2954,8 @@ namespace ip {
   {
   public:
     // types:
-    typedef InternetProtocol protocol_type;
-    typedef typename InternetProtocol::endpoint endpoint_type;
+    using protocol_type = InternetProtocol;
+    using endpoint_type = typename InternetProtocol::endpoint;
 
     // constructors:
     basic_resolver_entry();
@@ -3117,15 +3117,15 @@ namespace ip {
   {
   public:
     // types:
-    typedef InternetProtocol protocol_type;
-    typedef typename protocol_type::endpoint endpoint_type;
-    typedef basic_resolver_entry<protocol_type> value_type;
-    typedef const value_type& const_reference;
-    typedef value_type& reference;
-    typedef @\impdefx{type of \tcode{basic_resolver_results::const_iterator}}@ const_iterator;
-    typedef const_iterator iterator;
-    typedef ptrdiff_t difference_type;
-    typedef size_t size_type;
+    using protocol_type = InternetProtocol;
+    using endpoint_type = typename protocol_type::endpoint;
+    using value_type = basic_resolver_entry<protocol_type>;
+    using const_reference = const value_type&;
+    using reference = value_type&;
+    using const_iterator = @\impdefx{type of \tcode{basic_resolver_results::const_iterator}}@;
+    using iterator = const_iterator;
+    using difference_type = ptrdiff_t;
+    using size_type = size_t;
 
     // construct / copy / destroy:
     basic_resolver_results();
@@ -3340,7 +3340,7 @@ namespace ip {
   class resolver_base
   {
   public:
-    typedef @\textit{T1}@ flags;
+    using flags = @\textit{T1}@;
     static const flags passive;
     static const flags canonical_name;
     static const flags numeric_host;
@@ -3430,10 +3430,10 @@ namespace ip {
   public:
     // types:
 
-    typedef io_context::executor_type executor_type;
-    typedef InternetProtocol protocol_type;
-    typedef typename InternetProtocol::endpoint endpoint_type;
-    typedef basic_resolver_results<InternetProtocol> results_type;
+    using executor_type = io_context::executor_type;
+    using protocol_type = InternetProtocol;
+    using endpoint_type = typename InternetProtocol::endpoint;
+    using results_type = basic_resolver_results<InternetProtocol>;
 
     // construct / copy / destroy:
 
@@ -3859,11 +3859,11 @@ namespace ip {
   {
   public:
     // types:
-    typedef basic_endpoint<tcp> endpoint;
-    typedef basic_resolver<tcp> resolver;
-    typedef basic_stream_socket<tcp> socket;
-    typedef basic_socket_acceptor<tcp> acceptor;
-    typedef basic_socket_iostream<tcp> iostream;
+    using endpoint = basic_endpoint<tcp>;
+    using resolver = basic_resolver<tcp>;
+    using socket = basic_stream_socket<tcp>;
+    using acceptor = basic_socket_acceptor<tcp>;
+    using iostream = basic_socket_iostream<tcp>;
     class no_delay;
 
     // static members:
@@ -3990,9 +3990,9 @@ namespace ip {
   {
   public:
     // types:
-    typedef basic_endpoint<udp> endpoint;
-    typedef basic_resolver<udp> resolver;
-    typedef basic_datagram_socket<udp> socket;
+    using endpoint = basic_endpoint<udp>;
+    using resolver = basic_resolver<udp>;
+    using socket = basic_datagram_socket<udp>;
 
     // static members:
     static constexpr udp v4() noexcept;

--- a/src/sockets.tex
+++ b/src/sockets.tex
@@ -1014,17 +1014,17 @@ inline namespace v1 {
     class send_buffer_size;
     class send_low_watermark;
 
-    typedef @\placeholder{T1}@ shutdown_type;
+    using shutdown_type = @\placeholder{T1}@;
     static constexpr shutdown_type shutdown_receive;
     static constexpr shutdown_type shutdown_send;
     static constexpr shutdown_type shutdown_both;
 
-    typedef @\placeholder{T2}@ wait_type;
+    using wait_type = @\placeholder{T2}@;
     static constexpr wait_type wait_read;
     static constexpr wait_type wait_write;
     static constexpr wait_type wait_error;
 
-    typedef @\placeholder{T3}@ message_flags;
+    using message_flags = @\placeholder{T3}@;
     static constexpr message_flags message_peek;
     static constexpr message_flags message_out_of_band;
     static constexpr message_flags message_do_not_route;
@@ -1417,10 +1417,10 @@ inline namespace v1 {
   public:
     // types:
 
-    typedef io_context::executor_type executor_type;
-    typedef @\textit{implementation defined}@ native_handle_type; // \nativeref
-    typedef Protocol protocol_type;
-    typedef typename protocol_type::endpoint endpoint_type;
+    using executor_type = io_context::executor_type;
+    using native_handle_type = @\textit{implementation defined}@; // \nativeref
+    using protocol_type = Protocol;
+    using endpoint_type = typename protocol_type::endpoint;
 
     // basic_socket operations:
 
@@ -2195,9 +2195,9 @@ inline namespace v1 {
   public:
     // types:
 
-    typedef @\textit{implementation defined}@ native_handle_type; // \nativeref
-    typedef Protocol protocol_type;
-    typedef typename protocol_type::endpoint endpoint_type;
+    using native_handle_type = @\textit{implementation defined}@; // \nativeref
+    using protocol_type = Protocol;
+    using endpoint_type = typename protocol_type::endpoint;
 
     // construct / copy / destroy:
 
@@ -2854,9 +2854,9 @@ inline namespace v1 {
   public:
     // types:
 
-    typedef @\textit{implementation defined}@ native_handle_type; // \nativeref
-    typedef Protocol protocol_type;
-    typedef typename protocol_type::endpoint endpoint_type;
+    using native_handle_type = @\textit{implementation defined}@; // \nativeref
+    using protocol_type = Protocol;
+    using endpoint_type = typename protocol_type::endpoint;
 
     // construct / copy / destroy:
 
@@ -3326,11 +3326,11 @@ inline namespace v1 {
   public:
     // types:
 
-    typedef io_context::executor_type executor_type;
-    typedef @\textit{implementation defined}@ native_handle_type; // \nativeref
-    typedef AcceptableProtocol protocol_type;
-    typedef typename protocol_type::endpoint endpoint_type;
-    typedef typename protocol_type::socket socket_type;
+    using executor_type = io_context::executor_type;
+    using native_handle_type = @\textit{implementation defined}@; // \nativeref
+    using protocol_type = AcceptableProtocol;
+    using endpoint_type = typename protocol_type::endpoint;
+    using socket_type = typename protocol_type::socket;
 
     // construct / copy / destroy:
 

--- a/src/sockets.tex
+++ b/src/sockets.tex
@@ -121,7 +121,7 @@ inline namespace v1 {
 \end{codeblock}
 
 \pnum
-The figure below illustrates relationships between various types described in this Technical Specification. A solid line from \textbf{A} to \textbf{B} that is terminated by an open arrow indicates that \textbf{A} is derived from \textbf{B}. A solid line from \textbf{A} to \textbf{B} that starts with a diamond and is terminated by a solid arrow indicates that \textbf{A} contains an object of type \textbf{B}. A dotted line from \textbf{A} to \textbf{B} indicates that \textbf{A} is an alias for the class template \textbf{B} with the specified template argument.
+The figure below illustrates relationships between various types described in this Technical Specification. A solid line from \textbf{A} to \textbf{B} that is terminated by an open arrow indicates that \textbf{A} is derived from \textbf{B}. A solid line from \textbf{A} to \textbf{B} that starts with a diamond and is terminated by a solid arrow indicates that \textbf{A} contains an object of type \textbf{B}. A dotted line from \textbf{A} to \textbf{B} indicates that \textbf{A} is a synonym for the class template \textbf{B} with the specified template argument.
 
 \begin{importgraphic}
 {Socket and socket stream types [non-normative]}

--- a/src/sockets.tex
+++ b/src/sockets.tex
@@ -121,7 +121,7 @@ inline namespace v1 {
 \end{codeblock}
 
 \pnum
-The figure below illustrates relationships between various types described in this Technical Specification. A solid line from \textbf{A} to \textbf{B} that is terminated by an open arrow indicates that \textbf{A} is derived from \textbf{B}. A solid line from \textbf{A} to \textbf{B} that starts with a diamond and is terminated by a solid arrow indicates that \textbf{A} contains an object of type \textbf{B}. A dotted line from \textbf{A} to \textbf{B} indicates that \textbf{A} is a typedef for the class template \textbf{B} with the specified template argument.
+The figure below illustrates relationships between various types described in this Technical Specification. A solid line from \textbf{A} to \textbf{B} that is terminated by an open arrow indicates that \textbf{A} is derived from \textbf{B}. A solid line from \textbf{A} to \textbf{B} that starts with a diamond and is terminated by a solid arrow indicates that \textbf{A} contains an object of type \textbf{B}. A dotted line from \textbf{A} to \textbf{B} indicates that \textbf{A} is an alias for the class template \textbf{B} with the specified template argument.
 
 \begin{importgraphic}
 {Socket and socket stream types [non-normative]}

--- a/src/socketstreams.tex
+++ b/src/socketstreams.tex
@@ -23,12 +23,12 @@ inline namespace v1 {
   public:
     // types:
 
-    typedef Protocol protocol_type;
-    typedef typename protocol_type::endpoint endpoint_type;
-    typedef Clock clock_type;
-    typedef typename clock_type::time_point time_point;
-    typedef typename clock_type::duration duration;
-    typedef WaitTraits wait_traits_type;
+    using protocol_type = Protocol;
+    using endpoint_type = typename protocol_type::endpoint;
+    using clock_type = Clock;
+    using time_point = typename clock_type::time_point;
+    using duration = typename clock_type::duration;
+    using wait_traits_type = WaitTraits;
 
     // construct / copy / destroy:
 
@@ -356,12 +356,12 @@ inline namespace v1 {
   public:
     // types:
 
-    typedef Protocol protocol_type;
-    typedef typename protocol_type::endpoint endpoint_type;
-    typedef Clock clock_type;
-    typedef typename clock_type::time_point time_point;
-    typedef typename clock_type::duration duration;
-    typedef WaitTraits wait_traits_type;
+    using protocol_type = Protocol;
+    using endpoint_type = typename protocol_type::endpoint;
+    using clock_type = Clock;
+    using time_point = typename clock_type::time_point;
+    using duration = typename clock_type::duration;
+    using wait_traits_type = WaitTraits;
 
     // construct / copy / destroy:
 

--- a/src/timers.tex
+++ b/src/timers.tex
@@ -45,9 +45,9 @@ inline namespace v1 {
   template<class Clock, class WaitTraits = wait_traits<Clock>>
     class basic_waitable_timer;
 
-  typedef basic_waitable_timer<chrono::system_clock> system_timer;
-  typedef basic_waitable_timer<chrono::steady_clock> steady_timer;
-  typedef basic_waitable_timer<chrono::high_resolution_clock> high_resolution_timer;
+  using system_timer = basic_waitable_timer<chrono::system_clock>;
+  using steady_timer = basic_waitable_timer<chrono::steady_clock>;
+  using high_resolution_timer = basic_waitable_timer<chrono::high_resolution_clock>;
 
 } // inline namespace v1
 } // namespace net
@@ -174,11 +174,11 @@ inline namespace v1 {
   public:
     // types:
 
-    typedef io_context::executor_type executor_type;
-    typedef Clock clock_type;
-    typedef typename clock_type::duration duration;
-    typedef typename clock_type::time_point time_point;
-    typedef WaitTraits traits_type;
+    using executor_type = io_context::executor_type;
+    using clock_type = Clock;
+    using duration = typename clock_type::duration;
+    using time_point = typename clock_type::time_point;
+    using traits_type = WaitTraits;
 
     // construct / copy / destroy:
 


### PR DESCRIPTION
The first patch changes typedefs to using (type aliases), the second patch does the same
for the text. Q is if this last change rather should be 'type alias' or left as 'typedef'.