### PR TITLE
avoid \effects Results in favour of \results + trivial whitespace cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-https://github.com/cplusplus/networking-ts is the repository for the 
+https://github.com/cplusplus/networking-ts is the repository for the
 C++ Technical Specification "Extensions for Networking".
 
 The draft Technical Specification is found in the `src` directory

--- a/src/async.tex
+++ b/src/async.tex
@@ -340,7 +340,7 @@ The first parameter of all service constructors shall be an lvalue reference to 
 A service shall provide an explicit constructor with a single parameter of lvalue reference to \tcode{execution_context}. \begin{note} This constructor may be called by the \tcode{use_service} function. \end{note}
 
 \pnum
-\begin{example} 
+\begin{example}
 
 \begin{codeblock}
 class my_service : public execution_context::service
@@ -2651,7 +2651,7 @@ bool operator==(const executor& a, const executor& b) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns 
+\returns
 \begin{itemize}
 \item
 \tcode{true} if \tcode{!a} and \tcode{!b};
@@ -2729,7 +2729,7 @@ template<class CompletionToken>
 \completionsig \tcode{void()}.
 
 \pnum
-\effects 
+\effects
 \begin{itemize}
 \item
  Constructs an object \tcode{completion} of type \tcode{async_completion<CompletionToken, void()>}, initialized with \tcode{token}.
@@ -2751,7 +2751,7 @@ template<class Executor, class CompletionToken>
 \completionsig \tcode{void()}.
 
 \pnum
-\effects 
+\effects
 \begin{itemize}
 \item
  Constructs an object \tcode{completion} of type \tcode{async_completion<CompletionToken, void()>}, initialized with \tcode{token}.
@@ -2815,7 +2815,7 @@ template<class CompletionToken>
 \completionsig \tcode{void()}.
 
 \pnum
-\effects 
+\effects
 \begin{itemize}
 \item
  Constructs an object \tcode{completion} of type \tcode{async_completion<CompletionToken, void()>}, initialized with \tcode{token}.
@@ -2837,7 +2837,7 @@ template<class Executor, class CompletionToken>
 \completionsig \tcode{void()}.
 
 \pnum
-\effects 
+\effects
 \begin{itemize}
 \item
  Constructs an object \tcode{completion} of type \tcode{async_completion<CompletionToken, void()>}, initialized with \tcode{token}.
@@ -2901,7 +2901,7 @@ template<class CompletionToken>
 \completionsig \tcode{void()}.
 
 \pnum
-\effects 
+\effects
 \begin{itemize}
 \item
  Constructs an object \tcode{completion} of type \tcode{async_completion<CompletionToken, void()>}, initialized with \tcode{token}.
@@ -2923,7 +2923,7 @@ template<class Executor, class CompletionToken>
 \completionsig \tcode{void()}.
 
 \pnum
-\effects 
+\effects
 \begin{itemize}
 \item
  Constructs an object \tcode{completion} of type \tcode{async_completion<CompletionToken, void()>}, initialized with \tcode{token}.
@@ -3121,7 +3121,7 @@ strand(const strand& other) noexcept;
 \effects Initializes \tcode{inner_ex_} as \tcode{inner_ex_(other.inner_ex_)}.
 
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{*this == other}
@@ -3139,7 +3139,7 @@ strand(strand&& other) noexcept;
 \effects Initializes \tcode{inner_ex_} as \tcode{inner_ex_(std::move(other.inner_ex_))}.
 
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{*this} is equal to the prior value of \tcode{other}
@@ -3192,7 +3192,7 @@ strand& operator=(const strand& other) noexcept;
 \requires \tcode{Executor} is \tcode{CopyAssignable} (\CppXref{copyassignable}).
 
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{*this == other}
@@ -3213,7 +3213,7 @@ strand& operator=(strand&& other) noexcept;
 \requires \tcode{Executor} is \tcode{MoveAssignable} (\CppXref{moveassignable}).
 
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{*this} is equal to the prior value of \tcode{other}

--- a/src/basicioservices.tex
+++ b/src/basicioservices.tex
@@ -145,7 +145,7 @@ count_type run();
 \requires Must not be called from a thread that is currently calling a run function.
 
 \pnum
-\effects Equivalent to: 
+\effects Equivalent to:
 \begin{codeblock}
 count_type n = 0;
 while (run_one())
@@ -166,7 +166,7 @@ template<class Rep, class Period>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: 
+\effects Equivalent to:
 \begin{codeblock}
 return run_until(chrono::steady_clock::now() + rel_time);
 \end{codeblock}
@@ -181,7 +181,7 @@ template<class Clock, class Duration>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: 
+\effects Equivalent to:
 \begin{codeblock}
 count_type n = 0;
 while (run_one_until(abs_time))
@@ -224,7 +224,7 @@ template<class Rep, class Period>
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: 
+\effects Equivalent to:
 \begin{codeblock}
 return run_one_until(chrono::steady_clock::now() + rel_time);
 \end{codeblock}
@@ -258,7 +258,7 @@ count_type poll();
 
 \begin{itemdescr}
 \pnum
-\effects Equivalent to: 
+\effects Equivalent to:
 \begin{codeblock}
 count_type n = 0;
 while (poll_one())

--- a/src/buffers.tex
+++ b/src/buffers.tex
@@ -929,7 +929,7 @@ mutable_buffer operator+(size_t n, const mutable_buffer& b) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns A \tcode{mutable_buffer} equivalent to 
+\returns A \tcode{mutable_buffer} equivalent to
 \begin{codeblock}
 mutable_buffer(
   static_cast<char*>(b.data()) + min(n, b.size()),
@@ -945,7 +945,7 @@ const_buffer operator+(size_t n, const const_buffer& b) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns A \tcode{const_buffer} equivalent to 
+\returns A \tcode{const_buffer} equivalent to
 \begin{codeblock}
 const_buffer(
   static_cast<const char*>(b.data()) + min(n, b.size()),
@@ -1047,7 +1047,7 @@ template<class CharT, class Traits>
 
 \begin{itemdescr}
 \pnum
-\returns 
+\returns
 \begin{codeblock}
 buffer(
   begin(data) != end(data) ? std::addressof(*begin(data)) : nullptr,

--- a/src/cxx.tex
+++ b/src/cxx.tex
@@ -23,7 +23,7 @@
 
 \cxxsec{intro.compliance}{1.4}
 \cxxsec{intro.multithread}{1.10}
-  
+
 \cxxsec{lex.key}{2.12}
 
 \cxxsec{basic.def.odr}{3.2}
@@ -34,7 +34,7 @@
 \cxxsec{basic.compound}{3.9.2}
 
 \cxxsec{conv}{4}
-  
+
 \cxxsec{expr}{5}
 \cxxsec{expr.prim}{5.1}
 \cxxsec{expr.prim.general}{5.1.1}

--- a/src/internetprotocol.tex
+++ b/src/internetprotocol.tex
@@ -767,7 +767,7 @@ constexpr bool operator==(const address& a, const address& b) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns 
+\returns
 \begin{itemize}
 \item
  if \tcode{a.is_v4() != b.is_v4()}, \tcode{false};
@@ -795,7 +795,7 @@ constexpr bool operator< (const address& a, const address& b) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns 
+\returns
 \begin{itemize}
 \item
  if \tcode{a.is_v4() \&\& !b.is_v4()}, \tcode{true};
@@ -854,7 +854,7 @@ address make_address(string_view str, error_code& ec) noexcept;
 
 \begin{itemdescr}
 \pnum
-\effects Converts a textual representation of an address into an object of class \tcode{address}, as if by calling: 
+\effects Converts a textual representation of an address into an object of class \tcode{address}, as if by calling:
 \begin{codeblock}
 address a;
 address_v6 v6a = make_address_v6(str, ec);
@@ -1229,7 +1229,7 @@ constexpr address_v4 make_address_v4(v4_mapped_t, const address_v6& a);
 
 \begin{itemdescr}
 \pnum
-\returns An \tcode{address_v4} object corresponding to the IPv4-mapped IPv6 address, as if computed by the following method: 
+\returns An \tcode{address_v4} object corresponding to the IPv4-mapped IPv6 address, as if computed by the following method:
 \begin{codeblock}
 address_v6::bytes_type v6b = a.to_bytes();
 address_v4::bytes_type v4b(v6b[12], v6b[13], v6b[14], v6b[15]);
@@ -1477,7 +1477,7 @@ constexpr bool is_multicast() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns A boolean indicating whether the \tcode{address_v6} object represents a multicast address, as if computed by the following method: 
+\returns A boolean indicating whether the \tcode{address_v6} object represents a multicast address, as if computed by the following method:
 \begin{codeblock}
 bytes_type b = to_bytes();
 return b[0] == 0xFF;
@@ -1492,7 +1492,7 @@ constexpr bool is_link_local() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns A boolean indicating whether the \tcode{address_v6} object represents a unicast link-local address, as if computed by the following method: 
+\returns A boolean indicating whether the \tcode{address_v6} object represents a unicast link-local address, as if computed by the following method:
 \begin{codeblock}
 bytes_type b = to_bytes();
 return b[0] == 0xFE && (b[1] & 0xC0) == 0x80;
@@ -1507,7 +1507,7 @@ constexpr bool is_site_local() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns A boolean indicating whether the \tcode{address_v6} object represents a unicast site-local address, as if computed by the following method: 
+\returns A boolean indicating whether the \tcode{address_v6} object represents a unicast site-local address, as if computed by the following method:
 \begin{codeblock}
 bytes_type b = to_bytes();
 return b[0] == 0xFE && (b[1] & 0xC0) == 0xC0;
@@ -1522,7 +1522,7 @@ constexpr bool is_v4_mapped() const noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns A boolean indicating whether the \tcode{address_v6} object represents an IPv4-mapped IPv6 address, as if computed by the following method: 
+\returns A boolean indicating whether the \tcode{address_v6} object represents an IPv4-mapped IPv6 address, as if computed by the following method:
 \begin{codeblock}
 bytes_type b = to_bytes();
 return b[ 0] == 0 && b[ 1] == 0 && b[ 2] == 0    && b[ 3] == 0
@@ -1716,7 +1716,7 @@ constexpr address_v6 make_address_v6(v4_mapped_t, const address_v4& a) noexcept;
 
 \begin{itemdescr}
 \pnum
-\returns An \tcode{address_v6} object containing the IPv4-mapped IPv6 address corresponding to the specified IPv4 address, as if computed by the following method: 
+\returns An \tcode{address_v6} object containing the IPv4-mapped IPv6 address corresponding to the specified IPv4 address, as if computed by the following method:
 \begin{codeblock}
 address_v4::bytes_type v4b = a.to_bytes();
 address_v6::bytes_type v6b(0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -2715,7 +2715,7 @@ constexpr basic_endpoint(const protocol_type& proto,
 \requires \tcode{proto == protocol_type::v4() || proto == protocol_type::v6()}.
 
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
  If \tcode{proto == protocol_type::v6()}, \tcode{this->address() == ip::address_v6()}; otherwise, \tcode{this->address() == ip::address_v4()}.
@@ -2866,7 +2866,7 @@ template<class CharT, class Traits, class InternetProtocol>
 
 \begin{itemdescr}
 \pnum
-\effects Outputs a representation of the endpoint to the stream, as if it were implemented as follows: 
+\effects Outputs a representation of the endpoint to the stream, as if it were implemented as follows:
 \begin{codeblock}
 basic_ostringstream<CharT, Traits> ss;
 if (ep.protocol() == basic_endpoint<InternetProtocol>::protocol_type::v6())

--- a/src/macros.tex
+++ b/src/macros.tex
@@ -36,9 +36,9 @@
 }
 
 %%--------------------------------------------------
-%% Sectioning macros.  
-% Each section has a depth, an automatically generated section 
-% number, a name, and a short tag.  The depth is an integer in 
+%% Sectioning macros.
+% Each section has a depth, an automatically generated section
+% number, a name, and a short tag.  The depth is an integer in
 % the range [0,5].  (If it proves necessary, it wouldn't take much
 % programming to raise the limit from 5 to something larger.)
 
@@ -59,7 +59,7 @@
 
 % A convenience feature (mostly for the convenience of the Project
 % Editor, to make it easy to move around large blocks of text):
-% the \rSec macro is just like the \Sec macro, except that depths 
+% the \rSec macro is just like the \Sec macro, except that depths
 % relative to a global variable, SectionDepthBase.  So, for example,
 % if SectionDepthBase is 1,
 %   \rSec1[temp.arg.type]{Template type arguments}
@@ -84,7 +84,7 @@
 \newcommand{\indexgram}[1]{\index[grammarindex]{#1}}
 
 % Collation helper: When building an index key, replace all macro definitions
-% in the key argument with a no-op for purposes of collation. 
+% in the key argument with a no-op for purposes of collation.
 \newcommand{\nocode}[1]{#1}
 \newcommand{\idxmname}[1]{\_\_#1\_\_}
 \newcommand{\idxCpp}{C++}
@@ -313,8 +313,8 @@
         keepspaces=true,
         texcl=true}
 
-% Our usual abbreviation for 'listings'.  Comments are in 
-% italics.  Arbitrary TeX commands can be used if they're 
+% Our usual abbreviation for 'listings'.  Comments are in
+% italics.  Arbitrary TeX commands can be used if they're
 % surrounded by @ signs.
 \newcommand{\CodeBlockSetup}{
  \lstset{escapechar=@}

--- a/src/sockets.tex
+++ b/src/sockets.tex
@@ -2603,7 +2603,7 @@ template<class MutableBufferSequence, class CompletionToken>
 
 \begin{itemdescr}
 \pnum
-\effects Returns \tcode{async_receive_from(buffers, sender, socket_base::message_flags(), for\-ward<CompletionToken>(token))}.
+\returns \tcode{async_receive_from(buffers, sender, socket_base::message_flags(), for\-ward<CompletionToken>(token))}.
 \end{itemdescr}
 
 \begin{itemdecl}

--- a/src/sockets.tex
+++ b/src/sockets.tex
@@ -1544,7 +1544,7 @@ explicit basic_socket(io_context& ctx);
 
 \begin{itemdescr}
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{get_executor() == ctx.get_executor()}.
@@ -1562,7 +1562,7 @@ basic_socket(io_context& ctx, const protocol_type& protocol);
 \effects Opens this socket as if by calling \tcode{open(protocol)}.
 
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{get_executor() == ctx.get_executor()}.
@@ -1581,7 +1581,7 @@ basic_socket(io_context& ctx, const endpoint_type& endpoint);
 
 \begin{itemdescr}
 \pnum
-\effects Opens and binds this socket as if by calling: 
+\effects Opens and binds this socket as if by calling:
 \begin{codeblock}
 open(endpoint.protocol());
 bind(endpoint);
@@ -1589,7 +1589,7 @@ bind(endpoint);
 
 
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{get_executor() == ctx.get_executor()}.
@@ -1615,7 +1615,7 @@ basic_socket(io_context& ctx, const protocol_type& protocol,
 \effects Assigns the existing native socket into this socket as if by calling \tcode{assign(protocol, native_socket)}.
 
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{get_executor() == ctx.get_executor()}.
@@ -1637,7 +1637,7 @@ basic_socket(basic_socket&& rhs);
 \effects Move constructs an object of class \tcode{basic_socket<Protocol>} that refers to the state originally represented by \tcode{rhs}.
 
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{get_executor() == rhs.get_executor()}.
@@ -1667,7 +1667,7 @@ template<class OtherProtocol>
 \effects Move constructs an object of class \tcode{basic_socket<Protocol>} that refers to the state originally represented by \tcode{rhs}.
 
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{get_executor() == rhs.get_executor()}.
@@ -1713,7 +1713,7 @@ basic_socket& operator=(basic_socket&& rhs);
 \effects If \tcode{is_open()} is \tcode{true}, cancels all outstanding asynchronous operations associated with this socket. Completion handlers for canceled operations are passed an error code \tcode{ec} such that \tcode{ec == errc::operation_canceled} yields \tcode{true}. Disables the linger socket option to prevent the assignment from blocking, and releases socket resources as if by POSIX \tcode{close(native_handle())}. Moves into \tcode{*this} the state originally represented by \tcode{rhs}.
 
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{get_executor() == rhs.get_executor()}.
@@ -1744,7 +1744,7 @@ template<class OtherProtocol>
 \effects If \tcode{is_open()} is \tcode{true}, cancels all outstanding asynchronous operations associated with this socket. Completion handlers for canceled operations are passed an error code \tcode{ec} such that \tcode{ec == errc::operation_canceled} yields \tcode{true}. Disables the linger socket option to prevent the assignment from blocking, and releases socket resources as if by POSIX \tcode{close(native_handle())}. Moves into \tcode{*this} the state originally represented by \tcode{rhs}.
 
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{get_executor() == rhs.get_executor()}.
@@ -1797,7 +1797,7 @@ void open(const protocol_type& protocol, error_code& ec);
 \effects Establishes the postcondition, as if by POSIX \tcode{socket(protocol.family(), protocol.type(), protocol.protocol())}.
 
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{is_open() == true}.
@@ -1830,7 +1830,7 @@ void assign(const protocol_type& protocol,
 \effects Assigns the native socket handle to this socket object.
 
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{is_open() == true}.
@@ -1911,7 +1911,7 @@ template<class GettableSocketOption>
 
 \begin{itemdescr}
 \pnum
-\effects Gets an option from this socket, as if by POSIX: 
+\effects Gets an option from this socket, as if by POSIX:
 \begin{codeblock}
 socklen_t option_len = option.size(protocol_);
 int result = getsockopt(native_handle(), option.level(protocol_),
@@ -1974,7 +1974,7 @@ void native_non_blocking(bool mode, error_code& ec);
 
 \begin{itemdescr}
 \pnum
-\effects Sets the non-blocking mode of the underlying native socket, as if by POSIX: 
+\effects Sets the non-blocking mode of the underlying native socket, as if by POSIX:
 \begin{codeblock}
 int flags = fcntl(native_handle(), F_GETFL, 0);
 if (flags >= 0)
@@ -2070,7 +2070,7 @@ endpoint_type local_endpoint(error_code& ec) const;
 
 \begin{itemdescr}
 \pnum
-\effects Determines the locally-bound endpoint associated with the socket, as if by POSIX: 
+\effects Determines the locally-bound endpoint associated with the socket, as if by POSIX:
 \begin{codeblock}
 endpoint_type endpoint;
 socklen_t endpoint_len = endpoint.capacity();
@@ -2091,7 +2091,7 @@ endpoint_type remote_endpoint(error_code& ec) const;
 
 \begin{itemdescr}
 \pnum
-\effects Determines the remote endpoint associated with this socket, as if by POSIX: 
+\effects Determines the remote endpoint associated with this socket, as if by POSIX:
 \begin{codeblock}
 endpoint_type endpoint;
 socklen_t endpoint_len = endpoint.capacity();
@@ -2468,7 +2468,7 @@ template<class MutableBufferSequence>
 A read operation~(\ref{buffer.reqmts.read.write}).
 
 \pnum
-\effects Constructs an array \tcode{iov} of POSIX type \tcode{struct iovec} and length \tcode{iovlen}, corresponding to \tcode{buffers}, and reads data from this socket as if by POSIX: 
+\effects Constructs an array \tcode{iov} of POSIX type \tcode{struct iovec} and length \tcode{iovlen}, corresponding to \tcode{buffers}, and reads data from this socket as if by POSIX:
 \begin{codeblock}
 msghdr message;
 message.msg_name = nullptr;
@@ -2512,7 +2512,7 @@ template<class MutableBufferSequence, class CompletionToken>
 \completionsig \tcode{void(error_code ec, size_t n)}.
 
 \pnum
-\effects Initiates an asynchronous operation to read data from this socket. Constructs an array \tcode{iov} of POSIX type \tcode{struct iovec} and length \tcode{iovlen}, corresponding to \tcode{buffers}, then reads data as if by POSIX: 
+\effects Initiates an asynchronous operation to read data from this socket. Constructs an array \tcode{iov} of POSIX type \tcode{struct iovec} and length \tcode{iovlen}, corresponding to \tcode{buffers}, then reads data as if by POSIX:
 \begin{codeblock}
 msghdr message;
 message.msg_name = nullptr;
@@ -2571,7 +2571,7 @@ template<class MutableBufferSequence>
 A read operation~(\ref{buffer.reqmts.read.write}).
 
 \pnum
-\effects Constructs an array \tcode{iov} of POSIX type \tcode{struct iovec} and length \tcode{iovlen}, corresponding to \tcode{buffers}, and reads data from this socket as if by POSIX: 
+\effects Constructs an array \tcode{iov} of POSIX type \tcode{struct iovec} and length \tcode{iovlen}, corresponding to \tcode{buffers}, and reads data from this socket as if by POSIX:
 \begin{codeblock}
 msghdr message;
 message.msg_name = sender.data();
@@ -2622,7 +2622,7 @@ A read operation~(\ref{buffer.reqmts.read.write}).
 \completionsig \tcode{void(error_code ec, size_t n)}.
 
 \pnum
-\effects Initiates an asynchronous operation to read data from this socket. Constructs an array \tcode{iov} of POSIX type \tcode{struct iovec} and length \tcode{iovlen}, corresponding to \tcode{buffers}, then reads data as if by POSIX: 
+\effects Initiates an asynchronous operation to read data from this socket. Constructs an array \tcode{iov} of POSIX type \tcode{struct iovec} and length \tcode{iovlen}, corresponding to \tcode{buffers}, then reads data as if by POSIX:
 \begin{codeblock}
 msghdr message;
 message.msg_name = sender.data();
@@ -2678,7 +2678,7 @@ template<class ConstBufferSequence>
 A write operation~(\ref{buffer.reqmts.read.write}).
 
 \pnum
-\effects Constructs an array \tcode{iov} of POSIX type \tcode{struct iovec} and length \tcode{iovlen}, corresponding to \tcode{buffers}, and writes data to this socket as if by POSIX: 
+\effects Constructs an array \tcode{iov} of POSIX type \tcode{struct iovec} and length \tcode{iovlen}, corresponding to \tcode{buffers}, and writes data to this socket as if by POSIX:
 \begin{codeblock}
 msghdr message;
 message.msg_name = nullptr;
@@ -2721,7 +2721,7 @@ A write operation~(\ref{buffer.reqmts.read.write}).
 \completionsig \tcode{void(error_code ec, size_t n)}.
 
 \pnum
-\effects Initiates an asynchronous operation to write data to this socket. Constructs an array \tcode{iov} of POSIX type \tcode{struct iovec} and length \tcode{iovlen}, corresponding to \tcode{buffers}, then writes data as if by POSIX: 
+\effects Initiates an asynchronous operation to write data to this socket. Constructs an array \tcode{iov} of POSIX type \tcode{struct iovec} and length \tcode{iovlen}, corresponding to \tcode{buffers}, then writes data as if by POSIX:
 \begin{codeblock}
 msghdr message;
 message.msg_name = nullptr;
@@ -2769,7 +2769,7 @@ template<class ConstBufferSequence>
 A write operation~(\ref{buffer.reqmts.read.write}).
 
 \pnum
-\effects Constructs an array \tcode{iov} of POSIX type \tcode{struct iovec} and length \tcode{iovlen}, corresponding to \tcode{buffers}, and writes data to this socket as if by POSIX: 
+\effects Constructs an array \tcode{iov} of POSIX type \tcode{struct iovec} and length \tcode{iovlen}, corresponding to \tcode{buffers}, and writes data to this socket as if by POSIX:
 \begin{codeblock}
 msghdr message;
 message.msg_name = recipient.data();
@@ -2815,7 +2815,7 @@ A write operation~(\ref{buffer.reqmts.read.write}).
 \completionsig \tcode{void(error_code ec, size_t n)}.
 
 \pnum
-\effects Initiates an asynchronous operation to write data to this socket. Constructs an array \tcode{iov} of POSIX type \tcode{struct iovec} and length \tcode{iovlen}, corresponding to \tcode{buffers}, then writes data as if by POSIX: 
+\effects Initiates an asynchronous operation to write data to this socket. Constructs an array \tcode{iov} of POSIX type \tcode{struct iovec} and length \tcode{iovlen}, corresponding to \tcode{buffers}, then writes data as if by POSIX:
 \begin{codeblock}
 msghdr message;
 message.msg_name = recipient.data();
@@ -3092,7 +3092,7 @@ template<class MutableBufferSequence>
 A read operation~(\ref{buffer.reqmts.read.write}).
 
 \pnum
-\effects If \tcode{buffer_size(buffers) == 0}, returns immediately with no error. Otherwise, constructs an array \tcode{iov} of POSIX type \tcode{struct iovec} and length \tcode{iovlen}, corresponding to \tcode{buffers}, and reads data from this socket as if by POSIX: 
+\effects If \tcode{buffer_size(buffers) == 0}, returns immediately with no error. Otherwise, constructs an array \tcode{iov} of POSIX type \tcode{struct iovec} and length \tcode{iovlen}, corresponding to \tcode{buffers}, and reads data from this socket as if by POSIX:
 \begin{codeblock}
 msghdr message;
 message.msg_name = nullptr;
@@ -3143,7 +3143,7 @@ A read operation~(\ref{buffer.reqmts.read.write}).
 \completionsig \tcode{void(error_code ec, size_t n)}.
 
 \pnum
-\effects Initiates an asynchronous operation to read data from this socket. If \tcode{buffer_size(buffers) == 0}, the asynchronous operation completes immediately with no error and \tcode{n == 0}. Otherwise, constructs an array \tcode{iov} of POSIX type \tcode{struct iovec} and length \tcode{iovlen}, corresponding to \tcode{buffers}, then reads data as if by POSIX: 
+\effects Initiates an asynchronous operation to read data from this socket. If \tcode{buffer_size(buffers) == 0}, the asynchronous operation completes immediately with no error and \tcode{n == 0}. Otherwise, constructs an array \tcode{iov} of POSIX type \tcode{struct iovec} and length \tcode{iovlen}, corresponding to \tcode{buffers}, then reads data as if by POSIX:
 \begin{codeblock}
 msghdr message;
 message.msg_name = nullptr;
@@ -3239,7 +3239,7 @@ A write operation~(\ref{buffer.reqmts.read.write}).
 \completionsig \tcode{void(error_code ec, size_t n)}.
 
 \pnum
-\effects Initiates an asynchronous operation to write data to this socket. If \tcode{buffer_size(buffers) == 0}, the asynchronous operation completes immediately with no error and \tcode{n == 0}. Otherwise, constructs an array \tcode{iov} of POSIX type \tcode{struct iovec} and length \tcode{iovlen}, corresponding to \tcode{buffers}, then writes data as if by POSIX: 
+\effects Initiates an asynchronous operation to write data to this socket. If \tcode{buffer_size(buffers) == 0}, the asynchronous operation completes immediately with no error and \tcode{n == 0}. Otherwise, constructs an array \tcode{iov} of POSIX type \tcode{struct iovec} and length \tcode{iovlen}, corresponding to \tcode{buffers}, then writes data as if by POSIX:
 \begin{codeblock}
 msghdr message;
 message.msg_name = nullptr;
@@ -3467,7 +3467,7 @@ explicit basic_socket_acceptor(io_context& ctx);
 
 \begin{itemdescr}
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{get_executor() == ctx.get_executor()}.
@@ -3485,7 +3485,7 @@ basic_socket_acceptor(io_context& ctx, const protocol_type& protocol);
 \effects Opens this acceptor as if by calling \tcode{open(protocol)}.
 
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{get_executor() == ctx.get_executor()}.
@@ -3507,7 +3507,7 @@ basic_socket_acceptor(io_context& ctx, const endpoint_type& endpoint,
 
 \begin{itemdescr}
 \pnum
-\effects Opens and binds this acceptor as if by calling: 
+\effects Opens and binds this acceptor as if by calling:
 \begin{codeblock}
 open(endpoint.protocol());
 if (reuse_addr)
@@ -3518,7 +3518,7 @@ listen();
 
 
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{get_executor() == ctx.get_executor()}.
@@ -3546,7 +3546,7 @@ basic_socket_acceptor(io_context& ctx, const protocol_type& protocol,
 \effects Assigns the existing native acceptor into this acceptor as if by calling \tcode{assign(protocol, native_acceptor)}.
 
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{get_executor() == ctx.get_executor()}.
@@ -3570,7 +3570,7 @@ basic_socket_acceptor(basic_socket_acceptor&& rhs);
 \effects Move constructs an object of class \tcode{basic_socket_acceptor<AcceptableProtocol>} that refers to the state originally represented by \tcode{rhs}.
 
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{get_executor() == rhs.get_executor()}.
@@ -3600,7 +3600,7 @@ template<class OtherProtocol>
 \effects Move constructs an object of class \tcode{basic_socket_acceptor<AcceptableProtocol>} that refers to the state originally represented by \tcode{rhs}.
 
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{get_executor() == rhs.get_executor()}.
@@ -3648,7 +3648,7 @@ basic_socket_acceptor& operator=(basic_socket_acceptor&& rhs);
 \effects If \tcode{is_open()} is \tcode{true}, cancels all outstanding asynchronous operations associated with this acceptor, and releases acceptor resources as if by POSIX \tcode{close(native_handle())}. Then moves into \tcode{*this} the state originally represented by \tcode{rhs}. Completion handlers for canceled operations are passed an error code \tcode{ec} such that \tcode{ec == errc::operation_canceled} yields \tcode{true}.
 
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{get_executor() == rhs.get_executor()}.
@@ -3683,7 +3683,7 @@ template<class OtherProtocol>
 \effects If \tcode{is_open()} is \tcode{true}, cancels all outstanding asynchronous operations associated with this acceptor, and releases acceptor resources as if by POSIX \tcode{close(native_handle())}. Then moves into \tcode{*this} the state originally represented by \tcode{rhs}. Completion handlers for canceled operations are passed an error code \tcode{ec} such that \tcode{ec == errc::operation_canceled} yields \tcode{true}.
 
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{get_executor() == rhs.get_executor()}.
@@ -3740,7 +3740,7 @@ void open(const protocol_type& protocol, error_code& ec);
 \effects Establishes the postcondition, as if by POSIX \tcode{socket(protocol.family(), protocol.type(), protocol.protocol())}.
 
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{is_open() == true}.
@@ -3775,7 +3775,7 @@ void assign(const protocol_type& protocol,
 \effects Assigns the native acceptor handle to this acceptor object.
 
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{is_open() == true}.
@@ -3857,7 +3857,7 @@ template<class GettableSocketOption>
 
 \begin{itemdescr}
 \pnum
-\effects Gets an option from this acceptor, as if by POSIX: 
+\effects Gets an option from this acceptor, as if by POSIX:
 \begin{codeblock}
 socklen_t option_len = option.size(protocol_);
 int result = getsockopt(native_handle(), option.level(protocol_),
@@ -3920,7 +3920,7 @@ void native_non_blocking(bool mode, error_code& ec);
 
 \begin{itemdescr}
 \pnum
-\effects Sets the non-blocking mode of the underlying native acceptor, as if by POSIX: 
+\effects Sets the non-blocking mode of the underlying native acceptor, as if by POSIX:
 \begin{codeblock}
 int flags = fcntl(native_handle(), F_GETFL, 0);
 if (flags >= 0)
@@ -3986,7 +3986,7 @@ endpoint_type local_endpoint(error_code& ec) const;
 
 \begin{itemdescr}
 \pnum
-\effects Determines the locally-bound endpoint associated with this acceptor, as if by POSIX: 
+\effects Determines the locally-bound endpoint associated with this acceptor, as if by POSIX:
 \begin{codeblock}
 endpoint_type endpoint;
 socklen_t endpoint_len = endpoint.capacity();
@@ -4042,7 +4042,7 @@ socket_type accept(io_context& ctx, error_code& ec);
 
 \begin{itemdescr}
 \pnum
-\effects Extracts a socket from the queue of pending connections of the acceptor, as if by POSIX: 
+\effects Extracts a socket from the queue of pending connections of the acceptor, as if by POSIX:
 \begin{codeblock}
 native_handle_type h = accept(native_handle(), nullptr, 0);
 \end{codeblock}
@@ -4072,7 +4072,7 @@ template<class CompletionToken>
 \completionsig \tcode{void(error_code ec, socket_type s)}.
 
 \pnum
-\effects Initiates an asynchronous operation to extract a socket from the queue of pending connections of the acceptor, as if by POSIX: 
+\effects Initiates an asynchronous operation to extract a socket from the queue of pending connections of the acceptor, as if by POSIX:
 \begin{codeblock}
 native_handle_type h = accept(native_handle(), nullptr, 0);
 \end{codeblock}
@@ -4097,7 +4097,7 @@ socket_type accept(io_context& ctx, endpoint_type& endpoint,
 
 \begin{itemdescr}
 \pnum
-\effects Extracts a socket from the queue of pending connections of the acceptor, as if by POSIX: 
+\effects Extracts a socket from the queue of pending connections of the acceptor, as if by POSIX:
 \begin{codeblock}
 socklen_t endpoint_len = endpoint.capacity();
 native_handle_type h = accept(native_handle(),
@@ -4134,7 +4134,7 @@ template<class CompletionToken>
 \completionsig \tcode{void(error_code ec, socket_type s)}.
 
 \pnum
-\effects Initiates an asynchronous operation to extract a socket from the queue of pending connections of the acceptor, as if by POSIX: 
+\effects Initiates an asynchronous operation to extract a socket from the queue of pending connections of the acceptor, as if by POSIX:
 \begin{codeblock}
 socklen_t endpoint_len = endpoint.capacity();
 native_handle_type h = accept(native_handle(),

--- a/src/socketstreams.tex
+++ b/src/socketstreams.tex
@@ -274,7 +274,7 @@ virtual int_type underflow() override;
 \effects Behaves according to the description of \tcode{basic_streambuf<char>::underflow()}, with the specialization that a sequence of characters is read from the input sequence as if by POSIX \tcode{recvmsg}, and \tcode{ec_} is set to reflect the error code produced by the operation. If the operation does not complete before the absolute timeout specified by \tcode{expiry_}, the socket is closed and \tcode{ec_} is set to \tcode{errc::timed_out}.
 
 \pnum
-\effects Returns \tcode{traits_type::eof()} to indicate failure. Otherwise returns \tcode{traits_type::to_int_type(*gptr())}.
+\returns \tcode{traits_type::eof()} to indicate failure. Otherwise returns \tcode{traits_type::to_int_type(*gptr())}.
 \end{itemdescr}
 
 \begin{itemdecl}

--- a/src/timers.tex
+++ b/src/timers.tex
@@ -6,7 +6,7 @@
 This clause defines components for performing timer operations.
 
 \pnum
-\begin{example} Performing a synchronous wait operation on a timer: 
+\begin{example} Performing a synchronous wait operation on a timer:
 \begin{codeblock}
 io_context c;
 steady_timer t(c);
@@ -16,7 +16,7 @@ t.wait();
  \end{example}
 
 \pnum
-\begin{example} Performing an asynchronous wait operation on a timer: 
+\begin{example} Performing an asynchronous wait operation on a timer:
 \begin{codeblock}
 void handler(error_code ec) { ... }
 ...
@@ -239,7 +239,7 @@ basic_waitable_timer(io_context& ctx, const time_point& t);
 
 \begin{itemdescr}
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{get_executor() == ctx.get_executor()}.
@@ -269,7 +269,7 @@ basic_waitable_timer(basic_waitable_timer&& rhs);
 \effects Move constructs an object of class \tcode{basic_waitable_timer<Clock, WaitTraits>} that refers to the state originally represented by \tcode{rhs}.
 
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{get_executor() == rhs.get_executor()}.
@@ -308,7 +308,7 @@ basic_waitable_timer& operator=(basic_waitable_timer&& rhs);
 \effects Cancels any outstanding asynchronous operations associated with \tcode{*this} as if by calling \tcode{cancel()}, then moves into \tcode{*this} the state originally represented by \tcode{rhs}.
 
 \pnum
-\postconditions 
+\postconditions
 \begin{itemize}
 \item
 \tcode{get_executor() == rhs.get_executor()}.


### PR DESCRIPTION
This looked like some small tidbits that got forgotten in some earlier changes, and
very much editorial.

The eol ws clean up is just to get rid of an annoyance.