### PR TITLE
Use namespace std::experimental::net where possible

### DIFF
--- a/src/async.tex
+++ b/src/async.tex
@@ -12,8 +12,7 @@
 \indexlibrary{\idxcode{associated_executor_t}}%
 \begin{codeblock}
 namespace std {
-namespace experimental {
-namespace net {
+namespace experimental::net {
 inline namespace v1 {
 
   template<class CompletionToken, class Signature>
@@ -184,8 +183,7 @@ inline namespace v1 {
     class async_result<packaged_task<Result(Args...)>, Signature>;
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
+} // namespace experimental::net
 
   template<class Allocator>
     struct uses_allocator<experimental::net::v1::executor, Allocator>
@@ -785,9 +783,7 @@ determines the return type and return value of an asynchronous operation's initi
 \end{itemize}
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   template<class CompletionToken, class Signature>
@@ -805,9 +801,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -859,9 +853,7 @@ A type satisfying \tcode{MoveConstructible} requirements (\CppXref{moveconstruct
 Class template \tcode{async_completion} is provided as a convenience, to simplify the implementation of asynchronous operations that use \tcode{async_result}.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   template<class CompletionToken, class Signature>
@@ -879,9 +871,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -917,9 +907,7 @@ Initializes \tcode{result} with \tcode{completion_handler}.
 Class template \tcode{associated_allocator} is an associator~(\ref{async.reqmts.associator}) for the \tcode{ProtoAllocator}~(\ref{async.reqmts.proto.allocator}) type requirements, with default candidate type \tcode{allocator<void>} and default candidate object \tcode{allocator<void>()}.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   template<class T, class ProtoAllocator = allocator<void>>
@@ -931,9 +919,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \indextext{requirements!\idxcode{associated_allocator} specializations}%
@@ -1033,9 +1019,7 @@ template<class T, class ProtoAllocator>
 Class \tcode{execution_context} implements an extensible, type-safe, polymorphic set of services, indexed by service type.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   class execution_context
@@ -1071,9 +1055,7 @@ inline namespace v1 {
   class service_already_exists : public logic_error { };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -1219,9 +1201,7 @@ template<class Service> bool has_service(const execution_context& ctx) noexcept;
 
 \indexlibrary{\idxcode{execution_context::service}}%
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   class execution_context::service
@@ -1248,9 +1228,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \indexlibrary{\idxcode{execution_context::service}!constructor}%
@@ -1282,17 +1260,13 @@ execution_context& context() noexcept;
 The class template \tcode{is_executor} can be used to detect executor types satisfying the \tcode{Executor}~(\ref{async.reqmts.executor}) type requirements.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   template<class T> struct is_executor;
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -1308,18 +1282,14 @@ Class template \tcode{is_executor} is a UnaryTypeTrait (\CppXref{meta.rqmts}) wi
 \indexlibrary{\idxcode{executor_arg_t}}%
 \indexlibrary{\idxcode{executor_arg}}%
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   struct executor_arg_t { };
   constexpr executor_arg_t executor_arg = executor_arg_t();
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -1334,17 +1304,13 @@ The \tcode{executor_arg_t} struct is an empty structure type used as a unique ty
 
 \indexlibrary{\idxcode{uses_executor}}%
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   template<class T, class Executor> struct uses_executor;
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -1378,9 +1344,7 @@ otherwise, \tcode{obj} is initialized as \tcode{obj(v1, v2, ..., vN)}.
 Class template \tcode{associated_executor} is an associator~(\ref{async.reqmts.associator}) for the \tcode{Executor}~(\ref{async.reqmts.executor}) type requirements, with default candidate type \tcode{system_executor} and default candidate object \tcode{system_executor()}.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   template<class T, class Executor = system_executor>
@@ -1392,9 +1356,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \indextext{requirements!\idxcode{associated_executor} specializations}%
@@ -1517,9 +1479,7 @@ an executor of type \tcode{Executor} satisfying the Executor requirements~(\ref{
 to an object or function of type \tcode{T}.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   template<class T, class Executor>
@@ -1577,9 +1537,7 @@ inline namespace v1 {
     struct associated_executor<executor_binder<T, Executor>, Executor1>;
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 
@@ -1698,9 +1656,7 @@ template<class... Args>
 \indextext{\idxcode{async_result}!specialization for \tcode{executor_binder}}%
 \indexlibrary{\idxcode{async_result}}%
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   template<class T, class Executor, class Signature>
@@ -1723,9 +1679,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \begin{itemdecl}
@@ -1753,9 +1707,7 @@ return_type get();
 \indextext{\idxcode{associated_allocator}!specialization for \tcode{executor_binder}}%
 \indexlibrary{\idxcode{associated_allocator}}%
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   template<class T, class Executor, class ProtoAllocator>
@@ -1768,9 +1720,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \begin{itemdecl}
@@ -1790,9 +1740,7 @@ static type get(const executor_binder<T, Executor>& b,
 \indextext{\idxcode{associated_executor}!specialization for \tcode{executor_binder}}%
 \indexlibrary{\idxcode{associated_executor}}%
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   template<class T, class Executor, class Executor1>
@@ -1805,9 +1753,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \begin{itemdecl}
@@ -1863,9 +1809,7 @@ template<class ExecutionContext, class CompletionToken>
 
 \indexlibrary{\idxcode{executor_work_guard}}%
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   template<class Executor>
@@ -1901,9 +1845,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 
@@ -2065,9 +2007,7 @@ template<class T, class U>
 Class \tcode{system_executor} represents a set of rules where function objects are permitted to execute on any thread.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   class system_executor
@@ -2096,9 +2036,7 @@ inline namespace v1 {
   bool operator!=(const system_executor&, const system_executor&) noexcept;
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -2179,9 +2117,7 @@ bool operator!=(const system_executor&, const system_executor&) noexcept;
 Class \tcode{system_context} implements the execution context associated with \tcode{system_executor} objects.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   class system_context : public execution_context
@@ -2208,9 +2144,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -2284,9 +2218,7 @@ void join();
 An exception of type \tcode{bad_executor} is thrown by \tcode{executor} member functions \tcode{dispatch}, \tcode{post}, and \tcode{defer} when the executor object has no target.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   class bad_executor : public exception
@@ -2297,9 +2229,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \begin{itemdecl}
@@ -2325,8 +2255,7 @@ The \tcode{executor} class provides a polymorphic wrapper for types that satisfy
 
 \begin{codeblock}
 namespace std {
-namespace experimental {
-namespace net {
+namespace experimental::net {
 inline namespace v1 {
 
   class executor
@@ -2394,8 +2323,7 @@ inline namespace v1 {
   void swap(executor& a, executor& b) noexcept;
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
+} // namespace experimental::net
 
   template<class Allocator>
     struct uses_allocator<experimental::net::v1::executor, Allocator>
@@ -3043,9 +2971,7 @@ unless \tcode{is_convertible<Exec\-ution\-Context\&, execution_context\&>::value
 The class template \tcode{strand} is a wrapper around an object of type \tcode{Executor} satisfying the Executor requirements~(\ref{async.reqmts.executor}).
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   template<class Executor>
@@ -3100,9 +3026,7 @@ inline namespace v1 {
   bool operator!=(const strand<Executor>& a, const strand<Executor>& b);
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -3461,9 +3385,7 @@ bool operator!=(const strand<Executor>& a, const strand<Executor>& b);
 The class template \tcode{use_future_t} defines a set of types that, when passed as a completion token~(\ref{async.reqmts.async.token}) to an asynchronous operation's initiating function, cause the result of the asynchronous operation to be delivered via a future (\CppXref{futures.uniquefuture}).
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   template<class ProtoAllocator = allocator<void>>
@@ -3483,9 +3405,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 
@@ -3684,9 +3604,7 @@ Atomically stores \tcode{forward_as_tuple(forward<A$_0$>(a$_0$), ..., forward<A$
 \indexlibrary{\idxcode{async_result}}%
 \indextext{\idxcode{async_result}!specialization for \tcode{packaged_task}}%
 \begin{itemdecl}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   template<class Result, class... Args, class Signature>
@@ -3707,9 +3625,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 
 explicit async_result(completion_handler_type& h);
 \end{itemdecl}

--- a/src/basicioservices.tex
+++ b/src/basicioservices.tex
@@ -7,17 +7,13 @@
 \rSec1[io_context.synop]{Header \tcode{<experimental/io_context>} synopsis}
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   class io_context;
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 
@@ -26,9 +22,7 @@ inline namespace v1 {
 
 \indexlibrary{\idxcode{io_context}}%
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   class io_context : public execution_context
@@ -74,9 +68,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -333,9 +325,7 @@ void restart();
 
 \indexlibrary{\idxcode{io_context::executor_type}}%
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   class io_context::executor_type
@@ -372,9 +362,7 @@ inline namespace v1 {
                   const io_context::executor_type& b) noexcept;
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum

--- a/src/buffers.tex
+++ b/src/buffers.tex
@@ -12,8 +12,7 @@
 \indexlibrary{\idxcode{stream_errc}}%
 \begin{codeblock}
 namespace std {
-namespace experimental {
-namespace net {
+namespace experimental::net {
 inline namespace v1 {
 
   enum class stream_errc {
@@ -291,8 +290,7 @@ inline namespace v1 {
                              CompletionToken&& token);
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
+} // namespace experimental::net
 
   template<> struct is_error_code_enum<
     experimental::net::v1::stream_errc>
@@ -584,9 +582,7 @@ error_condition make_error_condition(stream_errc e) noexcept;
 
 \indexlibrary{\idxcode{mutable_buffer}}%
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   class mutable_buffer
@@ -607,9 +603,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -672,9 +666,7 @@ mutable_buffer& operator+=(size_t n) noexcept;
 \rSec1[buffer.const]{Class \tcode{const_buffer}}
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   class const_buffer
@@ -696,9 +688,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -774,9 +764,7 @@ const_buffer& operator+=(size_t n) noexcept;
 \indexlibrary{\idxcode{is_const_buffer_sequence}}%
 \indexlibrary{\idxcode{is_dynamic_buffer}}%
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   template<class T> struct is_mutable_buffer_sequence;
@@ -784,9 +772,7 @@ inline namespace v1 {
   template<class T> struct is_dynamic_buffer;
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -1117,9 +1103,7 @@ template<class CharT, class Traits>
 Class template \tcode{dynamic_vector_buffer} is an adaptor used to automatically grow or shrink a \tcode{vector} object, to reflect the data successfully transferred in an I/O operation.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   template<class T, class Allocator>
@@ -1152,9 +1136,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -1283,9 +1265,7 @@ size_ -= m;
 Class template \tcode{dynamic_string_buffer} is an adaptor used to automatically grow or shrink a \tcode{basic_string} object, to reflect the data successfully transferred in an I/O operation.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   template<class CharT, class Traits, class Allocator>
@@ -1318,9 +1298,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum

--- a/src/bufferstreams.tex
+++ b/src/bufferstreams.tex
@@ -214,9 +214,7 @@ Returns the maximum number of bytes to be transferred on the next \tcode{read_so
 The class \tcode{transfer_all} is a completion condition that is used to specify that a read or write operation should continue until all of the data has been transferred, or until an error occurs.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   class transfer_all
@@ -226,9 +224,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -252,9 +248,7 @@ size_t operator()(const error_code& ec, size_t) const;
 The class \tcode{transfer_at_least} is a completion condition that is used to specify that a read or write operation should continue until a minimum number of bytes has been transferred, or until an error occurs.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   class transfer_at_least
@@ -267,9 +261,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -302,9 +294,7 @@ size_t operator()(const error_code& ec, size_t n) const;
 The class \tcode{transfer_exactly} is a completion condition that is used to specify that a read or write operation should continue until an exact number of bytes has been transferred, or until an error occurs.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   class transfer_exactly
@@ -317,9 +307,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum

--- a/src/forward.tex
+++ b/src/forward.tex
@@ -7,9 +7,7 @@
 \rSec1[fwd.decl.synop]{Header \tcode{<experimental/netfwd>} synopsis}
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   class execution_context;
@@ -74,9 +72,7 @@ inline namespace v1 {
 
   } // namespace ip
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum

--- a/src/internetprotocol.tex
+++ b/src/internetprotocol.tex
@@ -13,8 +13,7 @@
 \indexlibrary{\idxcode{v4_mapped}}%
 \begin{codeblock}
 namespace std {
-namespace experimental {
-namespace net {
+namespace experimental::net {
 inline namespace v1 {
 namespace ip {
 
@@ -260,8 +259,7 @@ namespace ip {
   } // namespace multicast
 } // namespace ip
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
+} // namespace experimental::net
 
   template<> struct is_error_condition_enum<
     experimental::net::v1::ip::resolver_errc>
@@ -536,9 +534,7 @@ The class \tcode{address} is a version-independent representation for an IP addr
 \indexlibrary{\idxcode{address}!\idxcode{is_multicast}}%
 \indexlibrary{\idxcode{address}!\idxcode{to_string}}%
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 namespace ip {
 
@@ -596,9 +592,7 @@ namespace ip {
 
 } // namespace ip
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \indexlibrary{\idxcode{address}}%
@@ -905,9 +899,7 @@ The class \tcode{address_v4} is a representation of an IPv4 address.
 
 \indexlibrary{\idxcode{address_v4}}%
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 namespace ip {
 
@@ -969,9 +961,7 @@ namespace ip {
 
 } // namespace ip
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -982,9 +972,7 @@ namespace ip {
 
 \indexlibrarymember{bytes_type}{address_v4}%
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 namespace ip {
 
@@ -996,9 +984,7 @@ namespace ip {
 
 } // namespace ip
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -1300,9 +1286,7 @@ The class \tcode{address_v6} is a representation of an IPv6 address.
 
 \indexlibrary{\idxcode{address_v6}}%
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 namespace ip {
 
@@ -1371,9 +1355,7 @@ namespace ip {
 
 } // namespace ip
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -1387,9 +1369,7 @@ namespace ip {
 
 \indexlibrarymember{bytes_type}{address_v6}%
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 namespace ip {
 
@@ -1401,9 +1381,7 @@ namespace ip {
 
 } // namespace ip
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -1785,9 +1763,7 @@ template<class CharT, class Traits>
 An exception of type \tcode{bad_address_cast} is thrown by a failed \tcode{address_cast}.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 namespace ip {
 
@@ -1800,9 +1776,7 @@ namespace ip {
 
 } // namespace ip
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \begin{itemdecl}
@@ -1841,9 +1815,7 @@ template<> struct hash<experimental::net::v1::ip::address_v6>;
 The class template \tcode{basic_address_iterator} enables iteration over IP addresses in network byte order. This clause defines two specializations of the class template \tcode{basic_address_iterator}: \tcode{basic_address_iterator<address_v4>} and \tcode{basic_address_iterator<address_v6>}. The members and operational semantics of these specializations are defined below.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 namespace ip {
 
@@ -1876,9 +1848,7 @@ namespace ip {
 
 } // namespace ip
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -1968,9 +1938,7 @@ basic_address_iterator operator--(int) noexcept;
 The class template \tcode{basic_address_range} represents a range of IP addresses in network byte order. This clause defines two specializations of the class template \tcode{basic_address_range}: \tcode{basic_address_range<address_v4>} and \tcode{basic_address_range<address_v6>}. The members and operational semantics of these specializations are defined below.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 namespace ip {
 
@@ -1995,9 +1963,7 @@ namespace ip {
 
 } // namespace ip
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -2082,9 +2048,7 @@ Complexity: Constant time.
 The class \tcode{network_v4} provides the ability to use and manipulate IPv4 network addresses.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 namespace ip {
 
@@ -2132,9 +2096,7 @@ namespace ip {
 
 } // namespace ip
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -2365,9 +2327,7 @@ template<class CharT, class Traits>
 The class \tcode{network_v6} provides the ability to use and manipulate IPv6 network addresses.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 namespace ip {
 
@@ -2411,9 +2371,7 @@ namespace ip {
 
 } // namespace ip
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -2602,9 +2560,7 @@ template<class CharT, class Traits>
 An object of type \tcode{basic_endpoint<InternetProtocol>} represents a protocol-specific endpoint, where an endpoint consists of an IP address and port number. Endpoints may be used to identify sources and destinations for socket connections and datagrams.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 namespace ip {
 
@@ -2658,9 +2614,7 @@ namespace ip {
 
 } // namespace ip
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -2671,9 +2625,7 @@ Instances of the \tcode{basic_endpoint} class template meet the requirements for
  Extensible implementations provide the following member functions:
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 namespace ip {
 
@@ -2697,9 +2649,7 @@ namespace ip {
 
 } // namespace ip
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 
@@ -2952,9 +2902,7 @@ constexpr size_t capacity() const noexcept;
 An object of type \tcode{basic_resolver_entry<InternetProtocol>} represents a single element in the results returned by a name resolution operation.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 namespace ip {
 
@@ -2993,9 +2941,7 @@ namespace ip {
 
 } // namespace ip
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 
@@ -3117,9 +3063,7 @@ represents a sequence of \tcode{basic_res\-olver_entry<InternetProtocol>} elemen
 resulting from a single name resolution operation.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 namespace ip {
 
@@ -3171,9 +3115,7 @@ namespace ip {
 
 } // namespace ip
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -3342,9 +3284,7 @@ template<class InternetProtocol>
 
 \indexlibrary{\idxcode{resolve_base}}%
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 namespace ip {
 
@@ -3367,9 +3307,7 @@ namespace ip {
 
 } // namespace ip
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -3429,9 +3367,7 @@ If used with \tcode{v4_mapped}, return all matching IPv6 and IPv4 addresses.  \\
 Objects of type \tcode{basic_resolver<InternetProtocol>} are used to perform name resolution. Name resolution is the translation of a host name and service name into a sequence of endpoints, or the translation of an endpoint into its corresponding host name and service name.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 namespace ip {
 
@@ -3509,9 +3445,7 @@ namespace ip {
 
 } // namespace ip
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 
@@ -3860,9 +3794,7 @@ template<class Allocator>
 The class \tcode{tcp} encapsulates the types and flags necessary for TCP sockets.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 namespace ip {
 
@@ -3890,9 +3822,7 @@ namespace ip {
 
 } // namespace ip
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -3903,9 +3833,7 @@ The \tcode{tcp} class meets the requirements for an \tcode{InternetProtocol}~(\r
  Extensible implementations provide the following member functions:
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 namespace ip {
 
@@ -3920,9 +3848,7 @@ namespace ip {
 
 } // namespace ip
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -3991,9 +3917,7 @@ constexpr bool operator!=(const tcp& a, const tcp& b) noexcept;
 The class \tcode{udp} encapsulates the types and flags necessary for UDP sockets.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 namespace ip {
 
@@ -4018,9 +3942,7 @@ namespace ip {
 
 } // namespace ip
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -4031,9 +3953,7 @@ The \tcode{udp} class meets the requirements for an \tcode{InternetProtocol}~(\r
  Extensible implementations provide the following member functions:
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 namespace ip {
 
@@ -4048,9 +3968,7 @@ namespace ip {
 
 } // namespace ip
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -4215,12 +4133,9 @@ Satisfies the \tcode{BooleanSocket\-Option}~(\ref{socket.reqmts.opt.bool}) type 
 The \tcode{outbound_interface} class represents a socket option that specifies the network interface to use for outgoing multicast datagrams.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
-namespace ip {
-namespace multicast {
+namespace ip::multicast {
 
   class outbound_interface
   {
@@ -4230,12 +4145,9 @@ namespace multicast {
     explicit outbound_interface(unsigned int network_interface) noexcept;
   };
 
-} // namespace multicast
-} // namespace ip
+} // namespace ip::multicast
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -4246,12 +4158,9 @@ namespace multicast {
  Extensible implementations provide the following member functions:
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
-namespace ip {
-namespace multicast {
+namespace ip::multicast {
 
   class outbound_interface
   {
@@ -4266,12 +4175,9 @@ namespace multicast {
       unsigned int v6_value_; // \expos
   };
 
-} // namespace multicast
-} // namespace ip
+} // namespace ip::multicast
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \begin{itemdecl}

--- a/src/namespaces.tex
+++ b/src/namespaces.tex
@@ -6,12 +6,8 @@
 The components described in this Technical Specification are experimental and not part of the \Cpp standard library. All components described in this Technical Specification are declared in namespace \tcode{std::experimental::net::v1} or a sub-namespace thereof unless otherwise specified. The headers described in this technical specification shall import the contents of \tcode{std::experimental::net::v1} into \tcode{std::experimental::net} as if by:
 
 \begin{codeblock}
-namespace std {
-  namespace experimental {
-    namespace net {
+namespace std::experimental::net {
       inline namespace v1 {}
-    }
-  }
 }
 \end{codeblock}
 

--- a/src/sockets.tex
+++ b/src/sockets.tex
@@ -9,8 +9,7 @@
 \indexlibrary{\idxcode{socket_errc}}%
 \begin{codeblock}
 namespace std {
-namespace experimental {
-namespace net {
+namespace experimental::net {
 inline namespace v1 {
 
   enum class socket_errc {
@@ -110,8 +109,7 @@ inline namespace v1 {
                           CompletionToken&& token);
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
+} // namespace experimental::net
 
   template<> struct is_error_code_enum<
     experimental::net::v1::socket_errc>
@@ -1017,9 +1015,7 @@ error_condition make_error_condition(socket_errc e) noexcept;
 \rSec1[socket.base]{Class \tcode{socket_base}}
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   class socket_base
@@ -1060,9 +1056,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -1252,9 +1246,7 @@ Satisfies the \tcode{IntegerSocketOption}~(\ref{socket.reqmts.opt.int}) type req
 The \tcode{linger} class represents a socket option for controlling the behavior when a socket is closed and unsent data is present.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   class socket_base::linger
@@ -1273,9 +1265,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -1286,9 +1276,7 @@ inline namespace v1 {
  Extensible implementations provide the following member functions:
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   class socket_base::linger
@@ -1306,9 +1294,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \begin{itemdecl}
@@ -1429,9 +1415,7 @@ template<class Protocol> void resize(const Protocol& p, size_t s);
 Class template \tcode{basic_socket<Protocol>} is used as the base class for the \tcode{basic_datagram_socket<Protocol>} and \tcode{basic_stream_socket<Protocol>} class templates. It provides functionality that is common to both types of socket.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   template<class Protocol>
@@ -1550,9 +1534,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -2235,9 +2217,7 @@ When there are multiple outstanding asynchronous wait operations on this socket 
 The class template \tcode{basic_datagram_socket<Protocol>} is used to send and receive discrete messages of fixed maximum length.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   template<class Protocol>
@@ -2371,9 +2351,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -2897,9 +2875,7 @@ If the operation completes successfully, \tcode{n} is the number of bytes sent. 
 The class template \tcode{basic_stream_socket<Protocol>} is used to exchange data with a peer over a sequenced, reliable, bidirectional, connection-mode byte stream.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   template<class Protocol>
@@ -2998,9 +2974,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -3373,9 +3347,7 @@ template<class ConstBufferSequence, class CompletionToken>
 An object of class template \tcode{basic_socket_acceptor<AcceptableProtocol>} is used to listen for, and queue, incoming socket connections. Socket objects that represent the incoming connections are dequeued by calling \tcode{accept} or \tcode{async_accept}.
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   template<class AcceptableProtocol>
@@ -3505,9 +3477,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum

--- a/src/socketstreams.tex
+++ b/src/socketstreams.tex
@@ -12,9 +12,7 @@ The class \tcode{basic_socket_streambuf<Protocol, Clock, WaitTraits>} associates
  \begin{note} This class is intended for sending and receiving bytes, not characters. The conversion from characters to bytes, and vice versa, must occur elsewhere. \end{note}
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   template<class Protocol, class Clock, class WaitTraits>
@@ -71,9 +69,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -352,9 +348,7 @@ The class template \tcode{basic_socket_iostream<Protocol, Clock, WaitTraits>} su
  \begin{note} This class is intended for sending and receiving bytes, not characters. The conversion from characters to bytes, and vice versa, must occur elsewhere. \end{note}
 
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   template<class Protocol, class Clock, class WaitTraits>
@@ -402,9 +396,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum

--- a/src/timers.tex
+++ b/src/timers.tex
@@ -35,9 +35,7 @@ c.run();
 \begin{codeblock}
 #include <chrono>
 
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   template<class Clock> struct wait_traits;
@@ -50,9 +48,7 @@ inline namespace v1 {
   using high_resolution_timer = basic_waitable_timer<chrono::high_resolution_clock>;
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 
@@ -114,9 +110,7 @@ Returns a \tcode{Clock::duration} value to be used in a \tcode{wait} or \tcode{a
 
 \indexlibrary{\idxcode{wait_traits}}%
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   template<class Clock>
@@ -130,9 +124,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum
@@ -165,9 +157,7 @@ static typename Clock::duration to_wait_duration(
 
 \indexlibrary{\idxcode{basic_waitable_timer}}%
 \begin{codeblock}
-namespace std {
-namespace experimental {
-namespace net {
+namespace std::experimental::net {
 inline namespace v1 {
 
   template<class Clock, class WaitTraits = wait_traits<Clock>>
@@ -214,9 +204,7 @@ inline namespace v1 {
   };
 
 } // inline namespace v1
-} // namespace net
-} // namespace experimental
-} // namespace std
+} // namespace std::experimental::net
 \end{codeblock}
 
 \pnum


### PR DESCRIPTION
Collapse

namespace std {
namespace experimental {
namespace net
}}}

to

namespace std::experimental::net {
}